### PR TITLE
v2.6.0: Typst support and new default PDF engine (typst)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A minimal easy to use python document maker to create reports in `pdf`, `md`, `h
 
 
 - **NOTE:** some functions will try to call pandoc and fall back if not found.
-- **NOTE:** exporting PDFs need optional dependencies, such as either a latex compiler or Microsoft Word, or Libreoffice.
+- **NOTE:** exporting PDFs by default works using "typst". All other engines need optional dependencies, such as either a latex compiler or Microsoft Word, or Libreoffice.
 
 Full documentation at https://pydocmaker.readthedocs.io/en/latest/
 
@@ -123,7 +123,7 @@ Or alternatively:
 
 ```python
 doc.to_html('path/to/my_file.html') # will write a HTML file
-doc.to_pdf('path/to/my_file.pdf') # will write a PDF file
+doc.to_pdf('path/to/my_file.pdf') # will write a PDF file via typst
 doc.to_pdf('path/to/my_file.zip') # will write the whole latex project dir as a pdf file
 doc.to_markdown('path/to/my_file.md') # will write a Markdown file
 doc.to_docx('path/to/my_file.docx') # will write a docx file
@@ -132,6 +132,24 @@ doc.to_tex('path/to/my_file.tex.zip') # will pack all tex files and write them t
 doc.to_ipynb('path/to/my_file.ipynb') # will write a ipynb file
 
 doc.to_json('path/to/doc.json') # saves the document
+```
+
+
+### Configuring Options:
+
+All configurable options for this package are in `pydocmaker.options`. They are always callable 
+functions with "*_get", "*_set", "*_scan" etc. 
+
+```python
+
+import pydocmaker as pyd
+
+pyd.options.pandoc_allowed_set(False)
+print(pyd.options.pandoc_allowed_get())
+
+pyd.options.pdf_engine_set('typst') # default
+print(pyd.options.pdf_engine_get())
+
 ```
 
 

--- a/docs/datamodel.rst
+++ b/docs/datamodel.rst
@@ -1,0 +1,66 @@
+Data Model
+==========
+
+The underlying data model for ``pydocmaker`` is a list of dictionaries. Each dictionary represents a document element with a specific type (``typ``) and associated properties.
+
+Element Properties
+------------------
+
+Most elements share a common set of properties:
+
+*   ``typ``: The string identifier of the element type (e.g., "markdown", "image").
+*   ``children``: The main content of the element. For text-based types, this is a string. For containers like ``iter`` or ``table``, this is a list.
+*   ``color``: (Optional) A string representing a color (e.g., "red", "#FF0000") that backends will attempt to apply to the text content.
+*   ``end``: (Optional) A string to append after the element content, such as a custom line break.
+
+Supported Types
+---------------
+
+Based on the ``constr`` class in ``core.py``, here are the available types and their specific roles:
+
+*   **meta**:
+    Used to store document-wide metadata.
+    *   ``data``: A dictionary containing key-value pairs (e.g., ``title``, ``author``, ``template_id``).
+
+*   **markdown**:
+    Text content that should be parsed using Markdown syntax.
+
+*   **text**:
+    Basic plain text content.
+
+*   **line**:
+    Similar to ``text``, but defaults to appending a newline (``\n``).
+
+*   **latex**:
+    Raw LaTeX code. Backends that support LaTeX (like the PDF or TeX exporters) will pass this through directly.
+
+*   **verbatim**:
+    Preformatted text, typically rendered in a fixed-width font (like a code block).
+
+*   **iter**:
+    A container type used to group multiple document elements together.
+    *   ``children``: A list of other element dictionaries.
+
+*   **table**:
+    Represents tabular data.
+    *   ``children``: A list of lists (a matrix) containing the cell contents.
+    *   ``header``: (Optional) A list of strings for the table header row.
+    *   ``caption``: (Optional) A string description for the table.
+    *   ``borders``: (Boolean) Whether to render cell borders.
+    *   ``n_cols`` / ``n_rows``: (Optional) Dimensions of the table.
+
+*   **image**:
+    Embedded graphical content.
+    *   ``imageblob``: A base64-encoded string of the image data (prefixed with data URI scheme).
+    *   ``caption``: (Optional) Text to display under the image.
+    *   ``width``: (Optional) A number representing the scale or width of the image (often 0.0 to 1.0).
+    *   ``children``: Used as a filename or unique identifier for the image asset.
+
+JSON Definition
+---------------
+
+The following JSON file defines the structure for each supported element type:
+
+.. literalinclude:: ../src/pydocmaker/datamodel.json
+   :language: json
+   :caption: datamodel.json

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,7 @@ Links
    installation
    tldr
    examples
+   datamodel
 ..    high_level
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,16 +17,17 @@ a minimal python document maker to create reports in the following formats:
 - ``json``: JSON
 - ``docx``: Word docx
 - ``textile``: Textile Markup language (with images as attachments)
+- ``typst``: Typst Documents (with inline images)
 - ``ipynb``: Jupyter/ IPython Notebooks
 - ``tex``: Latex Documents (with external images)
 - ``redmine``: Textile Markup language ready for upload to Redmine 
 
-Written in pure python 
+Written purely in python, but with **optional** external non python dependencies.
 
 **NOTES:** 
    - some functions will try to call pandoc and fall back if not found.
-   - exporting PDFs need a latex compiler such as pdflatex, lualatex, xelatex
-   - When working with docx documents some functionalities (such as creating PDFs or updating references) need the ``win32com`` library and Microsoft Word installed in order to work.
+   - exporting PDFs works with typst under the hood if its installed. Else a latex compiler such as pdflatex, lualatex, xelatex is needed
+   - a subset of functions when working with docx documents (such as creating PDFs or updating references) need the ``win32com`` library and Microsoft Word installed in order to work.
 
 **Install** via:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,6 +9,14 @@ Install via:
 
    pip install pydocmaker
 
+**NOTE**: This will actually install the package will all subpackages, most of which are not needed, but kept for compatibility reasons. 
+If you want to install only the core package, you can do so via manually downloading the source , commenting out all the optional 
+dependencies in requirements.txt, and installing via:
+
+.. code-block:: bash
+
+   pip install -e .
+
 
 
 Install Optional Requirements

--- a/docs/s01_getting_started.ipynb
+++ b/docs/s01_getting_started.ipynb
@@ -690,7 +690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -706,7 +706,9 @@
    ],
    "source": [
     "doc.to_html('../exported_docs_examples/outfile.html') # will write a HTML file\n",
-    "doc.to_pdf('../exported_docs_examples/outfile.zip') # will write the whole latex project dir as a pdf file\n",
+    "doc.to_typst('../exported_docs_examples/outfile.typ') # will write a typst file\n",
+    "doc.to_pdf('../exported_docs_examples/outfile.zip') # will write a PDF file using the default engine (typst if installed, else pandoc, else latex)\n",
+    "doc.to_pdf('../exported_docs_examples/outfile.zip') # will write the whole latex project dir as a zip file\n",
     "doc.to_markdown('../exported_docs_examples/outfile.md') # will write a Markdown file\n",
     "doc.to_docx('../exported_docs_examples/outfile.docx') # will write a docx file\n",
     "doc.to_textile('../exported_docs_examples/outfile.textile.zip') # will pack all textile files and write them to a zip archive\n",
@@ -720,7 +722,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exporting to PDFs (via pandoc, LaTeX, Word, or Libreoffice)"
+    "### Exporting to PDFs (via typst, pandoc, LaTeX, Word, or Libreoffice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# will write a PDF file using typst (fastest, most robust and best looking engine if typst is installed, else will fallback to one of the below options)\n",
+    "doc.to_pdf('../exported_docs_examples/outfile_pdf_typst.pdf', engine=\"typst\") "
    ]
   },
   {

--- a/docs/tldr.rst
+++ b/docs/tldr.rst
@@ -4,7 +4,9 @@ TL;DR; Example
 This is a very small example if you're lazy ;-)
 
 .. code-block:: python
-
+    
+    import pydocmaker as pyd
+    
     doc = pyd.Doc() # basic doc where we always append to the end
     doc.add('dummy text') # adds raw text
 
@@ -19,3 +21,23 @@ This is a very small example if you're lazy ;-)
     doc.add_image("https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png", caption='', children='', width=0.8)
 
     doc.show()
+
+
+
+Configuring Options:
+====================
+
+All configurable options for this package are in ``pydocmaker.options``. They are always callable 
+functions with "*_get", "*_set", "*_scan" etc. 
+
+.. code-block:: python
+
+    import pydocmaker as pyd
+
+    pyd.options.pandoc_allowed_set(False)
+    print(pyd.options.pandoc_allowed_get())
+
+    pyd.options.pdf_engine_set('typst') # default
+    print(pyd.options.pdf_engine_get())
+
+

--- a/examples/04_minimal_doc.py
+++ b/examples/04_minimal_doc.py
@@ -1,5 +1,4 @@
 import sys, json
-sys.path.insert(0, r'C:\Users\tglaubach\repos\pydocmaker\src')
 
 import pydocmaker as pyd
 

--- a/examples/minimal_example_typst.pdf
+++ b/examples/minimal_example_typst.pdf
@@ -1,0 +1,1912 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 2
+  /Kids [117 0 R 119 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Outlines
+  /First 3 0 R
+  /Last 3 0 R
+  /Count 1
+>>
+endobj
+
+3 0 obj
+<<
+  /Parent 2 0 R
+  /First 4 0 R
+  /Last 7 0 R
+  /Count -2
+  /Title (1. My Typst Report)
+  /Dest 115 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Parent 3 0 R
+  /Next 7 0 R
+  /First 5 0 R
+  /Last 5 0 R
+  /Count -1
+  /Title (1.1. Some Example Text)
+  /Dest 113 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Parent 4 0 R
+  /First 6 0 R
+  /Last 6 0 R
+  /Count -1
+  /Title (1.1.1. The bedding was hardly able to cover it.)
+  /Dest 112 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Parent 5 0 R
+  /Title <FEFF0031002E0031002E0031002E0031002E0020005400680069006E006700730020007700650020006B006E006F0077002000610062006F0075007400200047007200650067006F00722019007300200073006C0065006500700069006E00670020006800610062006900740073002E>
+  /Dest 111 0 R
+>>
+endobj
+
+7 0 obj
+<<
+  /Parent 3 0 R
+  /Prev 4 0 R
+  /Title (1.2. Formatting and Images)
+  /Dest 114 0 R
+>>
+endobj
+
+8 0 obj
+<<
+  /Type /StructTreeRoot
+  /RoleMap <<
+    /Datetime /Span
+    /Terms /Part
+    /Title /P
+    /Strong /Span
+    /Em /Span
+  >>
+  /K [11 0 R]
+  /ParentTree <<
+    /Nums [0 78 0 R 1 9 0 R 2 10 0 R]
+  >>
+  /IDTree <<
+    /Names [(U1x0y0) 43 0 R (U1x1y0) 41 0 R (U1x2y0) 39 0 R]
+  >>
+  /ParentTreeNextKey 3
+>>
+endobj
+
+9 0 obj
+[82 0 R 82 0 R 81 0 R 81 0 R 76 0 R 80 0 R 76 0 R 76 0 R 79 0 R 76 0 R 76 0 R 76 0 R 77 0 R 76 0 R 76 0 R 76 0 R 76 0 R 75 0 R 75 0 R 74 0 R 74 0 R 74 0 R 73 0 R 73 0 R 72 0 R 71 0 R 69 0 R 68 0 R 66 0 R 65 0 R 63 0 R 62 0 R 59 0 R 59 0 R 59 0 R 59 0 R 59 0 R 59 0 R 59 0 R 58 0 R 58 0 R 57 0 R 56 0 R 55 0 R 54 0 R 53 0 R 52 0 R 51 0 R 49 0 R 47 0 R 44 0 R 42 0 R 40 0 R 36 0 R 34 0 R 32 0 R 29 0 R 27 0 R 25 0 R 22 0 R 20 0 R 18 0 R 46 0 R 13 0 R]
+endobj
+
+10 0 obj
+[12 0 R]
+endobj
+
+11 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 8 0 R
+  /K [82 0 R 81 0 R 76 0 R 75 0 R 74 0 R 73 0 R 60 0 R 59 0 R 58 0 R 57 0 R 50 0 R 48 0 R 47 0 R 14 0 R 13 0 R 12 0 R]
+>>
+endobj
+
+12 0 obj
+<<
+  /Type /StructElem
+  /S /Figure
+  /P 11 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [0]
+  /Pg 119 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [63]
+  /Pg 117 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 11 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0.4 0.4 0.45882353]
+    /BorderThickness 0.5
+  >>]
+  /K [45 0 R 37 0 R 15 0 R]
+>>
+endobj
+
+15 0 obj
+<<
+  /Type /StructElem
+  /S /TBody
+  /P 14 0 R
+  /K [30 0 R 23 0 R 16 0 R]
+>>
+endobj
+
+16 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 15 0 R
+  /K [21 0 R 19 0 R 17 0 R]
+>>
+endobj
+
+17 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [18 0 R]
+>>
+endobj
+
+18 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 17 0 R
+  /K [61]
+  /Pg 117 0 R
+>>
+endobj
+
+19 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [20 0 R]
+>>
+endobj
+
+20 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 19 0 R
+  /K [60]
+  /Pg 117 0 R
+>>
+endobj
+
+21 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 16 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [22 0 R]
+>>
+endobj
+
+22 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 21 0 R
+  /K [59]
+  /Pg 117 0 R
+>>
+endobj
+
+23 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 15 0 R
+  /K [28 0 R 26 0 R 24 0 R]
+>>
+endobj
+
+24 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 23 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [25 0 R]
+>>
+endobj
+
+25 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 24 0 R
+  /K [58]
+  /Pg 117 0 R
+>>
+endobj
+
+26 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 23 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [27 0 R]
+>>
+endobj
+
+27 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 26 0 R
+  /K [57]
+  /Pg 117 0 R
+>>
+endobj
+
+28 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 23 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [29 0 R]
+>>
+endobj
+
+29 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 28 0 R
+  /K [56]
+  /Pg 117 0 R
+>>
+endobj
+
+30 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 15 0 R
+  /K [35 0 R 33 0 R 31 0 R]
+>>
+endobj
+
+31 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 30 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x2y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [32 0 R]
+>>
+endobj
+
+32 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 31 0 R
+  /K [55]
+  /Pg 117 0 R
+>>
+endobj
+
+33 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 30 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x1y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [34 0 R]
+>>
+endobj
+
+34 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 33 0 R
+  /K [54]
+  /Pg 117 0 R
+>>
+endobj
+
+35 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 30 0 R
+  /A [<<
+    /O /Table
+    /Headers [(U1x0y0)]
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [36 0 R]
+>>
+endobj
+
+36 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 35 0 R
+  /K [53]
+  /Pg 117 0 R
+>>
+endobj
+
+37 0 obj
+<<
+  /Type /StructElem
+  /S /THead
+  /P 14 0 R
+  /K [38 0 R]
+>>
+endobj
+
+38 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 37 0 R
+  /K [43 0 R 41 0 R 39 0 R]
+>>
+endobj
+
+39 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 38 0 R
+  /ID (U1x2y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [40 0 R]
+>>
+endobj
+
+40 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 39 0 R
+  /K [52]
+  /Pg 117 0 R
+>>
+endobj
+
+41 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 38 0 R
+  /ID (U1x1y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [42 0 R]
+>>
+endobj
+
+42 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 41 0 R
+  /K [51]
+  /Pg 117 0 R
+>>
+endobj
+
+43 0 obj
+<<
+  /Type /StructElem
+  /S /TH
+  /P 38 0 R
+  /ID (U1x0y0)
+  /A [<<
+    /O /Table
+    /Scope /Column
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [44 0 R]
+>>
+endobj
+
+44 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 43 0 R
+  /K [50]
+  /Pg 117 0 R
+>>
+endobj
+
+45 0 obj
+<<
+  /Type /StructElem
+  /S /Caption
+  /P 14 0 R
+  /K [46 0 R]
+>>
+endobj
+
+46 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 45 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [62]
+  /Pg 117 0 R
+>>
+endobj
+
+47 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [49]
+  /Pg 117 0 R
+>>
+endobj
+
+48 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [49 0 R]
+>>
+endobj
+
+49 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 48 0 R
+  /K [48]
+  /Pg 117 0 R
+>>
+endobj
+
+50 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 11 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [56 0 R 55 0 R 54 0 R 53 0 R 52 0 R 51 0 R]
+>>
+endobj
+
+51 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [47]
+  /Pg 117 0 R
+>>
+endobj
+
+52 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [46]
+  /Pg 117 0 R
+>>
+endobj
+
+53 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [45]
+  /Pg 117 0 R
+>>
+endobj
+
+54 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [44]
+  /Pg 117 0 R
+>>
+endobj
+
+55 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [43]
+  /Pg 117 0 R
+>>
+endobj
+
+56 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 50 0 R
+  /K [42]
+  /Pg 117 0 R
+>>
+endobj
+
+57 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [41]
+  /Pg 117 0 R
+>>
+endobj
+
+58 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 11 0 R
+  /T (Formatting and Images)
+  /K [39 40]
+  /Pg 117 0 R
+>>
+endobj
+
+59 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [32 33 34 35 36 37 38]
+  /Pg 117 0 R
+>>
+endobj
+
+60 0 obj
+<<
+  /Type /StructElem
+  /S /L
+  /P 11 0 R
+  /A [<<
+    /O /List
+    /ListNumbering /Circle
+  >>]
+  /K [70 0 R 67 0 R 64 0 R 61 0 R]
+>>
+endobj
+
+61 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 60 0 R
+  /K [63 0 R 62 0 R]
+>>
+endobj
+
+62 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 61 0 R
+  /K [31]
+  /Pg 117 0 R
+>>
+endobj
+
+63 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 61 0 R
+  /K [30]
+  /Pg 117 0 R
+>>
+endobj
+
+64 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 60 0 R
+  /K [66 0 R 65 0 R]
+>>
+endobj
+
+65 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 64 0 R
+  /K [29]
+  /Pg 117 0 R
+>>
+endobj
+
+66 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 64 0 R
+  /K [28]
+  /Pg 117 0 R
+>>
+endobj
+
+67 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 60 0 R
+  /K [69 0 R 68 0 R]
+>>
+endobj
+
+68 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 67 0 R
+  /K [27]
+  /Pg 117 0 R
+>>
+endobj
+
+69 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 67 0 R
+  /K [26]
+  /Pg 117 0 R
+>>
+endobj
+
+70 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 60 0 R
+  /K [72 0 R 71 0 R]
+>>
+endobj
+
+71 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 70 0 R
+  /K [25]
+  /Pg 117 0 R
+>>
+endobj
+
+72 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 70 0 R
+  /K [24]
+  /Pg 117 0 R
+>>
+endobj
+
+73 0 obj
+<<
+  /Type /StructElem
+  /S /H4
+  /P 11 0 R
+  /T <FEFF005400680069006E006700730020007700650020006B006E006F0077002000610062006F0075007400200047007200650067006F00722019007300200073006C0065006500700069006E00670020006800610062006900740073002E>
+  /K [22 23]
+  /Pg 117 0 R
+>>
+endobj
+
+74 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [19 20 21]
+  /Pg 117 0 R
+>>
+endobj
+
+75 0 obj
+<<
+  /Type /StructElem
+  /S /H3
+  /P 11 0 R
+  /T (The bedding was hardly able to cover it.)
+  /K [17 18]
+  /Pg 117 0 R
+>>
+endobj
+
+76 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 11 0 R
+  /K [4 80 0 R 6 7 78 0 R 9 10 11 77 0 R 13 14 15 16]
+  /Pg 117 0 R
+>>
+endobj
+
+77 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 76 0 R
+  /K [12]
+  /Pg 117 0 R
+>>
+endobj
+
+78 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 76 0 R
+  /K [79 0 R <<
+    /Type /OBJR
+    /Pg 117 0 R
+    /Obj 116 0 R
+  >>]
+>>
+endobj
+
+79 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 78 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [8]
+  /Pg 117 0 R
+>>
+endobj
+
+80 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 76 0 R
+  /K [5]
+  /Pg 117 0 R
+>>
+endobj
+
+81 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 11 0 R
+  /T (Some Example Text)
+  /K [2 3]
+  /Pg 117 0 R
+>>
+endobj
+
+82 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 11 0 R
+  /T (My Typst Report)
+  /K [0 1]
+  /Pg 117 0 R
+>>
+endobj
+
+83 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /ADCUBT+LibertinusSerif-Bold-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [84 0 R]
+  /ToUnicode 87 0 R
+>>
+endobj
+
+84 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /ADCUBT+LibertinusSerif-Bold
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 86 0 R
+  /DW 0
+  /W [0 0 500 1 1 514 2 2 244 3 3 899 4 4 558 5 5 250 6 6 652 7 7 581 8 8 427 9 9 358 10 10 716 11 11 489 12 12 551 13 13 428 14 14 504 15 15 905 16 16 609 17 17 561 18 18 505.99997 19 19 325 20 20 529 21 21 322 22 22 616 23 23 521 24 24 619 25 25 542 26 26 561 27 27 777 28 28 456 29 29 613 30 30 598 31 31 732 32 32 252.99998 33 33 514 34 34 545 35 35 367 36 37 740 38 38 706]
+>>
+endobj
+
+85 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿÿ õû
+endstream
+endobj
+
+86 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /ADCUBT+LibertinusSerif-Bold
+  /Flags 131078
+  /FontBBox [0 -238 893 700]
+  /ItalicAngle 0
+  /Ascent 894
+  /Descent -246
+  /CapHeight 645
+  /StemV 168.6
+  /CIDSet 85 0 R
+  /FontFile3 88 0 R
+>>
+endobj
+
+87 0 obj
+<<
+  /Length 1138
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+38 beginbfchar
+<0001> <0031>
+<0002> <002E>
+<0003> <004D>
+<0004> <0079>
+<0005> <0020>
+<0006> <0054>
+<0007> <0070>
+<0008> <0073>
+<0009> <0074>
+<000A> <0052>
+<000B> <0065>
+<000C> <006F>
+<000D> <0072>
+<000E> <0053>
+<000F> <006D>
+<0010> <0045>
+<0011> <0078>
+<0012> <0061>
+<0013> <006C>
+<0014> <0076>
+<0015> <0069>
+<0016> <006E>
+<0017> <0067>
+<0018> <0068>
+<0019> <0062>
+<001A> <0064>
+<001B> <0077>
+<001C> <0063>
+<001D> <006B>
+<001E> <0075>
+<001F> <0047>
+<0020> <2019>
+<0021> <0032>
+<0022> <0046>
+<0023> <0049>
+<0024> <004E>
+<0025> <0041>
+<0026> <0043>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+88 0 obj
+<<
+  /Length 4745
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœXyxSeÖO)I.Ğ	ÒKj¹Wî­
+8Â0 Ã*Š"‚ÊV¡²–%MÚRº·IÓ=mÖ{o¶&iSš6İWÚ¦K ¥-”DqŠ2ã‚Œã03Œ"Î|êw.ßÛ¿§´lãèã¹¹ËsÎ{Ş³üÎï¼‚É“Ò×bÊSÒbÒS_—§Ä*æ¿x8jìÃ:äaƒ(~v€š* Yvü$~äo9èÊ#¡äÿ1ÂÙàÄôÙAÀ´³‚ï¿zlìÕ7AsÆş¾š+I^]•xP¾!J›¦~11I“vïnÑÂß,š¿há¢gÂ¶ÅÈÃîÙ¶%%ñ\–¶&=-&1%u@0I ˜›çæ×–ºK!ØÕæipˆPA˜š:É¸Nú}Ğ6hZ×T™!® _ğÒ@A€@ <1¶«™Ërc›³ïé±Ë©`Ác*7
+N>
+(7)!PØ4yÁäSÂTá¢•¢ñXø”Sş=Õ1õæ4å´¿™~Q"yArqzæCO?”;#b—‚ï9uf’ôQé;!OG°ü v€Ÿ3ÈNæ·¶ŒEŸü‹’ÂjpÀjäŠøSÒ±;4ö™à¸ıM8Z$F{`PŠÆàºHejåÏzXU0h äx)üKŒ8è8ÃRîBk&ÓŸFmJ|9õ™h.³(«TƒUŸn7—’n»a'.ˆ—í6l3R›îÒaŸr'¸®®æÓ 9.;[¥±cxÏ6ËnëUB‚ŞÖ ĞóûÏJå-ñ]]­-qM2Yl\%›ne½’7Â“HBVl
+íÖS€Im+ì+FŒëtlº]‡àşÂ55õ2GƒæØíl•Îş²ÅhÑ]ç—‡NÛÜ­ãoÑ^S(
+İ"Ô‹ĞËütÀ<.?kÄ`g´ÏËF†ê6ç¥†ë'Ô6q-\MÍ9¦éÚ6}“mÃkëøiB«vj„ZK±ÎNÚV§•Æ·A:_'4‹$6”ıõß,SŞ’´Ûa/<›P„à+@VIË´—4}ÛûA0“K›š}–ñ%0|U
+£fcb9EĞœ	Cğ#-Æ}Vô”Ê°,ÃPË1fjÈ…Çr¡îÔzŞ´M¨P0›™èØpNuGÁqƒC[ÿHQ¨Eo5Xnuq¶.'u[èáÜ<u"‰ïR­9¤<=Y•kÉræÓùNÖMº›¬öR_Qéj¨)öb4,¹ijåGºª`(‡0|„¦Kù‡Äï¸|íT•è÷ş”Õº¸‚³:iÜ§íÕŸbz0Îdf(|Ä‹õ«Hô¨÷­FSm9m2™Ú©‰Èß\¦„ÄG>ñv×^ ûE>—b=Š‹—eêW©	?ôs§¸w.2w‚­´dÚ®’«„4?|õnÀë ,ğx[:ºT¼,ß´IGŞÏù¹ÁÁnæØ]ùMÖ|ËU¦ˆó«*u5$<}ókxbXùvT'İ³óÈdÂö˜¸Z'25«X¢„)´å
+Íæœu&YeÖaCzWa8!È(§ØÎÚìD]£Ï]Mv÷íDS–ÆÏ&?Å^ŸBKP°¦“Ÿâ8ÂÏ ìƒyRë.Û‡ÓU¼“5L~ø¥ÿóÖÂú´Z:±å@í^/&óä´4Õm­q›j©rc1ç*ÂÚ-Ti\Šk±SG§¥å'&ñ%©Jª9v(¦)ëRG§qq™I‘»{?PRY–B&Ë€IĞš÷àÃxÂügA8à‡PüçùuÒœlC~. ÖsŒ•úÈ4A3w1ÎØJ5•Qİ^PC½ÕĞà¥Ktö<¥ÉM1dééz€ùß¯‰ˆ\¥V'İ,¶Íz
+¿†¦ˆ¸V¡ù]K/KØ=…_×*òµYt¦6A§-À´†¤•„–jü¹JèğCww0ˆ ìª&ÁSøIø÷­Ç¤2dÕÊÈ	(26–£sÅxî²Äû ¦‹»Ìuu½Ïtİ…˜m–DëU–ˆ?vjÓJiü$LA/#›»÷#»NYl.ÚZÄTXdZ?‘F€Bxºê£Sÿ$º²ÏmôQUŠmÅÏ“×Ñf)š¾&c)µv‹.VW}7I(É«š?Áâ.ÀıÁ> 	a@ßà_©ôÀÁíùrÿöÙİ=_ÑEœÕF€VTcó”~vè:z‚Æo<†‚ ù[+7‹¢c;ú³.‘#Û> İúr…Š`”k³u”z±š²zW1YïK^©csM&ZbÒøy‘?Àa°Â} “¢‡¿YÄ¥7½¾nêdçâ0/º\¶1!2Š’ïËÜ¼…€TxCz±wš‚öÄE/ƒé—ÿVvå]Z‚fT(áÌø
+B!*¥íÅGÜG(—ÃYt„thta‘§°šllhò×Å7EÇÈã7ì¥"S“¾Ÿ%œL¡#‡Ü“‘³AkÒ™3Æ«¡ œ@›^İIviüéğ¿¾;¸fÀsŒ÷ğËoM“:¶)+‘[rbĞŠøÄ½»¹kwu<Õ»ñjì±x¬7®Gö:±kì¦õë†şª¢ğŒ,{–!Û€1ÃÏ;"ŠŞsÆ¢Š|«¿Ü×M·7·ô¾MœJo‹?JE{½9Ê‹É¼kO!†[[O~Ö°zC9Uj¨e‹Ø ¡[{–’À·J»œé	ş
+B`Éøoæ#øÈëˆ»Å6Öf#j:Û\²«IN£•â¥Yïb•ŸkáúúšïÛ³Ì’éü#ÅµŒ×è¢*:•”‘]?&;tü~Y²Æea’l`‰b©,n+u,[Ö¸…Œ~QNãıÆ&c5KàW~¢şkPzî[ä€U3”aÖM½Uî·ª‚ÿ	aø·ğ>@º¶Šj<µ5Ôg¢ßWÊ×UÑ%¦J³Ë†á7ôİú/MÌÌpF
+ÿÖ˜YÈ¤’¨OÄ>Îíäî,÷Ñ£_FŒÎ/Ë4¼t¢Ç±ä‰úşbbéÒÛÇI=İœkÄ^TE¾ş9O”QYOƒúŠx¤"#ÒBÛuÍ¬İ1mLE+ÑÊUqM”Î~˜Õé°mFeÁzRâ0µò¢Ö`7üı"alG`~^ı@úöçV›ÅbÑÏê[è‰Ócô³&ìğrç¹ÁSo3Ş;ÎPØcİq}‹ááP½ƒµX¬×@ÚĞÚ^Ò|·O¿¥b3‡¢Şk³~­İèÈW%l_jÔëYCQäB•ínsÇÁTÌ+Ì¶]÷uf¬Ç›$k ¯!Üb`:í¬_#QJÜ¾üxÃËğ/×Ìµ;qÏ6¿¦¶¶W5c’=šs›ßƒ/üÁÇ!h.L‚©0ï†¾~éÁ¢zõqr¨³²ÍGã‡M%GÓäjÆ0[WŞO›aæ,j\şš|`CbIzg{]U±3vÊä2¹Ì.¬˜s”%ımj„Óë•B¼û±CkVë:¢?o<ÛRw”â`µ…ŠU))Yjrvc³ÏÒ|©š– Œ
+å­İ¬*økÁ}_.]–U°é¾ôîá†~ŞW	~ùÅÇRN­µ€Rä­Ì_k4æqù¶ì¼ŞÆ¬#$©N%¿¨5À2XÂü<éiCQVúUèÕPC¡ÈXô¬5ÙL6ÆšÓ¡+¾ÇŠdÌ®˜÷hÕY­Yåİ	£‘Ğl»Gç&]^s¥“†ÙpÁÛãn´ÍšLgâ˜t…‚Kº5	ÊªPòáªï`fÀ?ÇÀ3{¬Ã,U\`Ï¡óWşgnûy¨ˆH>Az¨æPWO]{]SZû=iqñ”äüm@ÃjX5×)ì×wuyË‚~Fö,‘­İ'ßFÛM?Ál~6lÄ¡?<÷÷íJøe(;'ƒ‹!à¹›¿‚ x$yÿÀ»ùh’6”•ø*’åû¶JN ñA—Zi$÷Ğ¤¢&'Eí v5Fô%Sxïó‡“vG¨ˆK+›ÂO„9sJ
+½:lò¾ğLBQ²¿>ƒJê¼ ë#†ÅÀ$ÿ(¬RsLVOÕE¡_­!ÕIæ®2W©­„ÖTV2Í$Ş=xò„»©•n¬ó¶õÃ‰¾ØÊå8Zî"E:…Îµ–+kIüã0Ô3ºTú!üÒuğšVŞa’“"ûO¶²ÕÅ^Úàr›*I¼gÄpAúTb^òÆÂË'/—×wğF­¢$nGtU02ü
+_3¥w¼¯X«ˆ	§ ZŒßøÉœ}EüÃêy ±°d;¯p@\ç?ZRNvµı¬\À¯Œgƒ$_ãÏTòÓ/{B`„ám——â	ËLy9…3”‹Iw±«ÔYÅw¾¥é%!¦À$xüLúpœîŞíŠ GÄ(hxCü“[‚/­:Ze©&û}‘O.ÏAØª„´’êZâĞ\€›ş|Ô3Æu^€ü]€>©9ÕœÉyœC_Jú\çJGœf»Ék²cÛmùeg>BŒû/ËæŞ]…ˆñwí©¶I‘	Ñ¬-•ëúåtb{mÎ0Yùxi%m?!ÍTF¤ç‘;£†aÊ ½·¢™®÷Ô—5‘uµÆC54bÄ…lWHI mŒ\ à È+áÒŒ¾¼ã,¡f2ØóÓÈjÔLW8¬e,Œ™±äøue÷jû™B’%£bHĞHhF‘Ûä&]æJıw`¿Df¡º¨Âè&]‹×AÃt8ë9æé¾¥ÔL²bÿ=e§¶äŒ][Ñ¢PC3¸0É¯4ïÃõ1Iò+>—–˜*ò)…,6#|~Ëi‚ÀÚ¡Aß‘¨8d©Wµ-ÕµÍ=ÛßDhêãO£_¾RŞ© ½Ù—Ès#ş¡ZrÎÔ
+/uÁüV0ßÉôùŒdğ
+~ó¿ãşñãLÍİŒ·f:®ŸŠšY.º:¶á G¹-ÙD²Øl²l¹­{˜ñİ‘ˆ²¦ã{Ï…ê‹L«m`(ÿ®¥­¾í»~xIVì¹ße	²ôøôT•ËÏİ›OÂç? ’ÍeS\ç}|Ì’ÂñÍy5„ÇP¬³SjFÅd$¾ÂEİm
+'õeÚ¥Ú(Ö°NC¥<dR“²xÛ{4¬|PRÉ¨wÈ¹ıw%{M•š¥Z(~Ô¿ıOí4¶œ¥Ì)æŒŸHv	¼¬ñC¡æÂj­?ø(<W!¿ÂÓ·æIŸ\txã:zıæ¨ß ñ›ö#[©íç?Nÿ–„É h=ı­qêÅcSoÛWƒ…²ÛÙZKdö0rÅ.ò¶])vvÊPgèIq\\ªf‰İK!ôOî|'éÁÎ¡ÊAB.¬^RKã7ÊLeæ{_? }Ã¯¼Ñ†f4xk“* ÈË ¹µIš¬¥¥T&Vèi·±º0HŞ±62ÒçršâBŸıxmCÖĞP×ßF|z¨{;%‰b?æs»ƒ¾{¦À"˜‰8Àï’¦T'´76V5ÛLEF'…_7ÅDu[oßÉ¶×6¯7ìØIıvzMÍL4&Í²Æ	ùQIGÉHÑÌ[`M#_NOHŠ$QˆÈÒâª?ÚôæéP˜“ºj®ß,>3‡Â?D¯›¿‘–šZÁÛÅ4øº¿ú±®ûÒQSÛTMTs­\ãƒdtÈÇ)ó_D¿¯Û›2»oSæ+Æã…_1w(ó	Ê<ğc”ù‡ãî§Œ»òÛçi›*”·f«jŠ®Ñ â½ÒÑ¹âŸ5,ósÅW¬Cjâ­Œy‘‘ÉÖp² 9ŒßØìT6+«•ü­Ö`àà[ÓBğU¬şR3Á/_óØŞ+¢&Šq“ÉˆTr;ïæú{Zq!ZÅ)¹¶…Êáw‹¾EKïÅ36ÅÚ“±Ñ%b|Ï¢LıKÚ{“Bwüxù}g?/eZşJÀ€ØevÙmmn1…{àÏ£	½)Ş–hsYœå´6›Zc¿<–/ø^p>_ĞÇOS[`1Z|+	ïåKºmvk	á"<m--‰N`ä¦Y:-£#ñ	|Ü\çƒXtˆQŸDù‘Ğ‚ìÍ11$Šu&oŒ×ï3Ş!ï>®œëìº'#·ì±”uc €ıÒt­Åe¥ÿiÂ"Ñ§H#”À|Í)şıî <È?ª‘Ş¸Ö{í"íÔg–ä“Ï®]‘ü‰°_Ã#°~ı	Ì„i@õ<»¤.1x-Åvı©Â¾‚!Ì¶#²M'Ñ´MGIó»Ñ¤O¶Ò{ßù(ó)ù&G8(
+endstream
+endobj
+
+89 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /VXYODJ+LibertinusSerif-Regular-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [90 0 R]
+  /ToUnicode 93 0 R
+>>
+endobj
+
+90 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /VXYODJ+LibertinusSerif-Regular
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 92 0 R
+  /DW 0
+  /W [0 0 500 1 1 702 2 2 542 3 3 447 4 4 250 5 5 790 6 6 504 7 7 372 8 8 271 9 9 500 10 10 220 11 11 747 12 12 538 13 13 685 14 14 485 15 15 457 16 16 390 17 17 512 18 18 310 19 19 316 20 20 531 21 21 493 22 22 264 23 23 505.99997 24 24 220 25 25 730 26 26 515 27 27 338 28 28 428 29 29 596 30 30 497 31 31 582 32 32 597 33 33 519 34 34 424 35 35 375 36 36 951 37 37 268 38 38 435 39 39 375 40 40 297 41 41 560 42 42 351 43 44 298 45 45 490 46 46 485 47 47 503.00003 48 48 236 49 49 322 50 50 701 51 52 465 53 53 699 54 54 575 55 56 465 57 57 528 58 58 695 59 59 839 60 60 646 61 61 250 62 62 465]
+>>
+endobj
+
+91 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿş #ãø
+endstream
+endobj
+
+92 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /VXYODJ+LibertinusSerif-Regular
+  /Flags 131078
+  /FontBBox [-68 -238 947 736]
+  /ItalicAngle 0
+  /Ascent 894
+  /Descent -246
+  /CapHeight 658
+  /StemV 95.4
+  /CIDSet 91 0 R
+  /FontFile3 94 0 R
+>>
+endobj
+
+93 0 obj
+<<
+  /Length 1486
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+62 beginbfchar
+<0001> <004F>
+<0002> <006E>
+<0003> <0065>
+<0004> <0020>
+<0005> <006D>
+<0006> <006F>
+<0007> <0072>
+<0008> <0069>
+<0009> <0067>
+<000A> <002C>
+<000B> <0077>
+<000C> <0068>
+<000D> <0047>
+<000E> <0053>
+<000F> <0061>
+<0010> <0073>
+<0011> <006B>
+<0012> <0066>
+<0013> <0074>
+<0014> <0075>
+<0015> <0062>
+<0016> <006C>
+<0017> <0064>
+<0018> <002E>
+<0019> <0048>
+<001A> <0079>
+<001B> <002D>
+<001C> <0063>
+<001D> <00660074>
+<001E> <0076>
+<001F> <00660066>
+<0020> <0054>
+<0021> <0070>
+<0022> <007A>
+<0023> <201C>
+<0024> <0057>
+<0025> <2019>
+<0026> <003F>
+<0027> <201D>
+<0028> <0049>
+<0029> <00660069>
+<002A> <2022>
+<002B> <0028>
+<002C> <0029>
+<002D> <0078>
+<002E> <0046>
+<002F> <0071>
+<0030> <003A>
+<0031> <004A>
+<0032> <0044>
+<0033> <0033>
+<0034> <0030>
+<0035> <004E>
+<0036> <0059>
+<0037> <0032>
+<0038> <0035>
+<0039> <004C>
+<003A> <0041>
+<003B> <004D>
+<003C> <0043>
+<003D> <00A0>
+<003E> <0031>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+94 0 obj
+<<
+  /Length 6900
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœY	xSÕ¶nnÈ `Ô#å=T®Š€  Od’™2
+e(t.‡¤s†f<9™§ÎIgÒ¦i›h)-P@d¸Ñ¢È$rÁëÌÛwßó})tĞëÕû½ïë—fØkg­íõ¯¯0FŒ`0A+ãvE¥eÄ%e¦¯J‹‹~s]TLfÂÎ4ÿg‹iŒ~Q3§_€ 4šÇ£9/~•-/a??b½ĞõÌKŒ‘Ï½ğË/£'øßúaôDÿ¿û£'06oÅüÈä]QË"£’2â2²&§d§ÅÅÄfŒz6}ê´éoNŸ:}Æ¸±Qã†Ü·&-9>*"cÜüÌŒØä´ô)	`¼/²Óó‹Êíày«§ÈeeC©ƒdÚ~ı”fô¨æ‘½£zM£Ÿ¦»ùÌ F@@@Àşˆ§4Ê€ß·×ü=ø·[PÇH`\d\ùËuæ›Ì#–²²²Ù‹9Ïsª¹÷ÀS«GÎÙ9ê­Q×Fç¾ò´ıé6^ú3ãŸYüŒéYñs	´"!ÈçWògóSøÿûÂÎzÆÈÆÔ¹ôÚØWÇ~ŠŠPö<¦~‘ûbôKÏ¾t_‹DÌ NŒ³{4®o|Xˆ¦‹şG7CÓEOìbjFĞªGÁ}*öµÿy‘æ˜M¬>6İÅ÷?ƒşW ˜ú?cõ8p+8Ä‡s‘î±yà5I3}¯™Ñò€^ö€ùh
+øœ"àË€—À§Àp3x>ææíÎO{pß±Ê_ ğ6èàƒ ÿ†Ûá’™ ò 0ÀıÍo¨B@=¤>¸òA/ïE.‚•àg>Ò&—ÉÕ”¬S{V.â6¨ÕºB,Yœ*],UËµ¹Z9÷ˆÂ¦X‹ÂMœÙåj.—kF9×Eù(ŸÏEºFO45N¹‘jè?GÁ,rÆi±›-xKk{¥s82ì„U¨MIDáşM6)p…\#0ø7i¤|¾fÿ&£Æ©0r×ÄşM&sz”xeN‚=C.nY_°dÁ'9"¼`”›Ñò»É¤_¸ÇŠNÊ]‹Åìtv'B·¨ã8
+*Ô,»Éhû"ñKHÌ€¬YğõÅ!î("¢é@úìÊÏ!¡²Ê"ŠKÀZ>`Uœ·Tc­í‚w¥J…˜àÁc< @ì½`½ÿïù‘ƒ`.ø™OºÔÍ
++÷¡*PlPAÕJù|¿‚ª?ÊYä³ÇPy}-¬µ>})pf*B”ÕP-”Ïç&k1Ú¬—>GÁÛœbM1iÇw¶y±ÖÊÌ¥\Ä™-Qlú­‡¬´İğØv:çNŞù·CWemØ„«Tr…ÚÂm“F6nÂÖnŠÛº“@*riçò6K<ô3FÛM »Él;ù“ÎB˜pú`•»	oßï8õ1úã:ğ4|sYHJx4µv%
+6ƒ0şÍÃïÃ‰0pyÂÖ—ã@àÕ[Î;_<¸¼B üsÕI0ğÛ+ô"E`ø™¯ö‘µşãgù#Lg‰”«1õP^Êçë =ƒ˜~hé®£€à 5µö*{9^j«rÛ1‹E-6È1‰É^P†UWÕÔÈŠì=;·îÚ™#Er±Âl@y°¹B@/3i„à¹o5ÂÀ/¿}»i Ë Â8È©.ıi®Wè
+ñdqÄs=
+«|]¿sbUğ`m¸ûk%İƒÎ!Áz±ş:Š´M¥Sù©Õ©ÕõÕuÎjA}
+¸Ó“ÓÓ	^”¶€µ' Ñ R.‡4h„çv}>ÿ0Ør­¼¹ê¤×ĞcøåågViJjXN\*\tšEñ5ØôÙ«ß
+©N¨O!¶ğäôÜğ84Æ‘\[€#—¦†ìNŞÎø<å*ÀÀ+g@@c^MR5Şù!!Ÿ„g§©Ué™'!XRlñ>‡Ñi/#ò«ëe^ìög=ÿ<_—ä"¬&Gqf2©¤F¹ê,ÔIlri*<Ó7¯²•ª‹êuÅX×^2wáÍ´ç§¢ÇGM‹ywÏÙ&mÍ\t‚Õ`/ÊÖ¬èw¥Ÿœ>_ÓÜsªiÛ,œoÁ± ‹Æx™?Şç'd
+’j%å*¢B]&Ï@1Û6à­Ì$ÃOØwGO¤z#p±è)n†	LùLq`$ì 'ğŸ@HÆ’1Q)Têè‰Ór@a“871ğJP¾Ñ,·b³±ÔD|È Å|«ÄH€1à|i[Y}·nì“Í„d&™˜¸“JØì²R’”û.Œ’¤)5…Î™ 9(ë€ÖzX?øõdbZüÅ¥=©|»17èCøaA¼š,h;ìÊê¤J;ucy¹ıl¶»Ê¬aàí^İ‹üÌ^ş —vÿ	—ÖSMı<áş=.=˜ázÂ¥[V,	&HRC’¸J©ÛQ
+d²Ëgô>nRê¤8r7M2/?B¥.Ôæå\N£Ãö«lšÿBû–ù‹pí`ºıôÒêöÓË ±é¥úë(Œ‘4ƒÂfp©¿“¿Á¤Ÿ~ô
+Îóá˜—‚gáK`=y¯æøYBlQ˜m(àr<eÖ=:ÜhÔTËÜt2ŒˆßJíèÇ/İ(çö(ë”(|“³;n©<ƒÓßïƒ °°ÁhÀ“ÚfÍ¬%l¤Mk3¨÷*|¹¸ÖÕÑÈÄx‹%Íà-zkS`÷'@úÒNFñÍkµ“±W¦/?áVØí8âDÆ¥äÉè{ÛwÎ™²zß7™8’U —¨%
+ı\}ª}i?UŸqkßg«ôÇ››?>>œs`v¾ºòÕÖ/Ğ£İG?úºaÕ2nSQ“²SY/9ÌåıUÒ¶«“ál¾¾â*˜ù)Ò::ù	F[JÖÚ\æpH‚Ú®´ˆ\¹,GR€%‘Ş¼ÊŞ¯[0{VÈºt»¨jO¹³ÈDšÔzœÔ‘FÚ°×ÖÚt ²d*¥ŠÄg
+XHÛëé‹7.AgM=ïq™›öãR–¬âÃ N\V(Ç©qÉØæL_C»³ãRÁƒ³$nµ€ş«[#ì©ÎùŒ¿‚Äwœ¯ß¢ÛºÕZ­”CLFÚDÈêê”-ØÑê¾9»Å·¤†@êVWE”ô mÍUM•Çß)Âre4r›®YÛB¹¹H!!¬x6iØŠî„«»‰ëq‚ptK˜ G"3‹l"³J¼_^ÃEâåÆ,R.çòvªİ`q˜åÑkáf/˜	¦ _İ<ş,±rı°Ó×Dù<n²jğôíêçØ[œ
+²˜´ªl…©=÷âä =‘ö,JÄUQjî *)GCé0ŠÓ§éSš`x/HiPé¨^£ÕëñÛw]³O?@ d2Me”óQez¬T”‘”—š•™›"ÊRqÁ÷äÁ°:úñßÕª*ô‹^ jb<èe‚…ş.ã¼Ç±ë-„ƒ£Wi88ÆS:ªİ®RQl1m¶å;±²j§£L\.(%ÊSSuQØ»SÀ©DD('[!*$
+8
+ŠÔãç “=+W2¬Wz(Ÿ¯sX¯|_/÷—)”JzÀ?½`¢…q§—¹ÏÏWíó<Â^ÔÜÑÑU¹ß‹«­r£„â
+SS±¹ë$Œ?r¬Ã=íe÷GoTéJ©R!ÅÅr‰¢@Å)%*™Hg‚L”—!9 «£Gös\h/Ò%|ï‡ï aĞ[´”Œ«K3ÇiP³Ê@µ\$«²ÜSò±ÉhÔ”ÈÜiÅAlà¸ô5¸N¥Sà
+2ÌÛCÅ$†{PU$Z†"í0„“¥.Ìá»££rÓ°ÄÍÅw°üM;•Åâå(ÜÀYìZúÎ–4©4±€–?íq7‘z0‡Æùr¹RkAÁJÒ8,åéÿ–:ó8‘d¶*Gê¥3­³Åj7jlRnV•KîÁ¾£î·oÚåáQ9É	„)_Uë²ìÁ>îšÿWÈŞ6óAe :So-²á<¸¯Bğh±ß·û½HËışQ«†2ßò!¬®£ôNrnÈí_9}\iTÍCyaş<o=±{o‚”^¤Üêâ$*İ;”¨İ¿“(z3g6¾‡|#S«e¸rWY<¶lGfTºf>
+Ÿ99àH½·Å@l—ø	İ›†…¬ÿ<w¡ØWâ$4ìÕ9°æš‚Qœ«“% <xKòqì!óØ>~Ruú=ÕÕ{ö¤W'%¥§'á<°¨B ®ì-BÆÃàş&ı¿€Ç§'q®—Î÷· ~:!CÉ¨è°'-ÈçyU™b
+gÀû`Æ¯×F‘»ÈĞÍ»¨¨ß¬í›Ä™•£øp0#û©Nªµù ¹H·êr×QîÃ°_¯m§:©––ÎYË‹„yWé.w ¼	æ p{ Îà—ÖÕÛ]×@Hû‡ÀÇŞâÒÆ	úÌ “†$	¹×¨j”çÆ¼³ƒd¹RU¡c:ˆÊŞ«¨8: c¢É2&.…ùEÒÚ`À‚¥AaÉ6I²(^”œ—ÀŠó¥iùJKÊK,8rëœ>óéf‚@ú	†Ø˜ ¤ó‹ŠëíV¥UBÀd¶¨ #[b”Z”¤™nFËM&=á._i)ÔK)î¸ğÌplAğ%ğøKçßşö‘96VO¤èŠ¥NÌY_ÔĞ³Î÷úkã§Ã	a:<q¸âó.‚·WÒ“ÚO¯­Ÿ5>è{‘°Fù`#é†G8ÿ/Zë?ÅkSIRMªÉ±
+µR¥@µ™é¥F¥DáÆcì2MY	Jî%eÜjseq	V_œ“d'rLv±«(.q–JË„%D‰0Ñ…%mËİN$Fn|ı
+G
+f‰‡‘xÕLy<ûHßàaXÒßíxëTğ[ <ÅŸÒøG”F‘ ô=”©Ğäî]B‚²;•öÃ¦'¶ñd,Ÿ8tËM¹Pğ<<”g4Ê‹0«ÉXf"ÀXğ·Šı¶š£†!%œN¦ÆÇQiƒ‡ˆWÿ¸™¥¹²=_ö‚°^ä3z}Kûê×Hf;¨vc~±¸ÖR‰U;ó…B`µfÕa’GÛ6÷üèu™ãäëê‚íMs°”T™H@,ˆ_yèöpˆşîïrÃrSÍTscÙ8Ğ6}ş:
+œ :9³ÄÊƒk÷PTSã>rßĞí³Çp.¦ƒùÒ2RˆFÀ0ùú¬Ùc¬À¯9Ûm%˜§<=ÍF-a-†|¦ÕQEğö©İô¯YÊo çÀ~"	äœ¶¶6ã•ìËRç–¶bJo!Y‡¢›lçRj-‰#çTq©ø/l&i™GtQ„Z­&	åvÉ&qWiµ“v9wÍÑQû7ì »ÅLôñı1g!Rİ”¯µ›ìŒcÎc†ˆ…qÑD³:tÂÀkş‘ø&Ò¦Ò#üÓ‹ş»öå{×îû€ó;]¤sXYÔàéI«—Ô¸äØÑ®2oq £îäg(rÿá¼NÚš¸=Gzår¥†´r‘»ÑüÆÚ×ìtÏBÈš4	È5”fÂr¥±Ë9N½Å^Œóàš¦\Á/JğKÀËâ€Àš‰´|B¯à«•J5AnWÄJ·X”vµ]ç¸ØPæ¢Àóº %ı*œøş®T¤Q)P™YQ‚#)àŒÊŞTtÈÔ5V/iEÒ’Ÿ”¶Q¹‰Ç²/ıãG0íä÷Ü’Yê:®HV'ap{·È`È#xp	m YŞ^‹ËÛkA®6mà7T:ëS-Ù:"K›c¬BÚÙÜq¨·ªM2¾Z¼6ìC¹ºº6Ò‡ƒi/üvõ¿®í_É£Ç[Øî@-˜€ùzÀ10ùéQ7}’§ö-VQ§ßË9âÑ5^Mw‘;ÈˆøXj÷«}XU™`I­Z¤é$RTBæà;|…yêíÀñä226‰JØ ]e"+BÀš¾Ö \ƒQlÃŠŒV?L·Y‹Î`Àôzq‘ xƒ•c4Hì˜Íd+1`İ\ä)¯êt.‰ÜM¦¦î "†œû©MåSå…syĞû(XÈ S½LÀü_ûá(ÉCºÎØqvÉµò‡‹İ_]Gî6}ïòU;ÖºnùÖ¼¤ˆh|ùÅšptGfV™Í	ßÏ©¦ª‹jpK™£´ªŒ{ éäş^ôî²“päòÆùiIDbº 9
+­),­pØ«ŠÔF¥Gî*jc	ŠôºújGIÀ%ıAyÁH/ó§ÿ<0í…ÿ8`k…àÑK~¥ÂëG¦ì ·’‘ñ[¨­"=Ú©ƒTss'Ùş[9aìçï"!P4ù‡I~ş÷ów9èí|ÉµJùL”˜DÆbpó1öı¦ëg÷5‰w™ñÍVg^Vét8O¾Ó9eÛ†ì°]ÄÎ-Òà÷Ñ¼-œ?$ìÇ­}­¬ĞKöNƒYJÀÍşyÃĞ Õã§x—l’³{ Ü¸ ‹qd1O‚şÊîĞS§º»O
+í^¹24t%ÎƒşóËŒı×™û¿]sA$\Š[µf“ÎÌo…O”¢ Œxc3®²ÊLbŠGMšçÀ`”-–àƒëL`~»äÂH°—¨eªB®;
+<qXŠÂR8â»cpÄ$³‘\0êû{`Fy+Ôn0î6 Üe ‚Ùğ0¹ù“*ğ|Ì€(x©›–ƒŸùM&ªİğ$Âr™˜˜84ÆjRÕçÔïº‘ ƒL£R*¸ÈyïÂ€ˆĞLU¬zì¤ü×\—«¬jp?ˆcô…úÊÆSwƒÌv=i”Ÿä	ËUïV©İTskY=`³]—§‹86 AJ#©3ıßôÅ·¨648â
+ğËÊÄÄä!¹Èy-J›*=nùÔ ™DIÚ¸¼ÅğiëYaµlğé…?İ@zA3¸Â¿¡ËØ®#Œr§Æ?<¸OÖ{šĞ&ª–ªõw£@#—s7¨Tï`SÀRö»u?ŞÎ~X±¸’°Û´:3\V´å=P›¹Z’RáH¯*GA¦aĞÌŞ½¢"ˆ?¬	ÕEµ·>F~,Ç·qx¡ı=tv9ÍiÒ	=7Af/r|™ş9ÄŸ\²ü³Ş¿Ó5œb¥M,“ŠqärA¶R%2s»#-;1È›ö*šr
+>&Ö¹Ö2ÙWU¤×
+Ğtzß‘©ÏKG‘Ë0‡“M*
+d¸(#…ÌÅÖÎØ^ÿqï¥k²ÏU'J«$xğÓC°á!ãüCæùÿJP {ÄïVœ×ş(ÛÍ ão0€vğ¯—N»Ë„“‘1©Íƒ	½ö¼`\º)9>+ß^"ÃíriQ–Ÿ(ÈŒ9œ]ÙŞ`ö´û[/£<ğªº‰ş´‰ñğÍyÀ¯=ËÙø§ÉğR‡©Ö–½êFOãAği@‚`ø&xn mPGbûúóéÇS|$|Â)p;|z3?YìhÄyÓ%ú€'ğÀE°øÓĞÛÈw`7}¿Ï—ºbóÚ¹¯å†İ,mY¹¦Cî»”Ypìô”ØPiU¹ˆ(–Ø…˜@•ñEÊ	0êáU³½k¬©e!ß}î­j;ŒºdÕé5xeflÙ&¾ºóõø|«°Ú£wWœ>g¯%|=Ã{Dİb‚,	ÿ*xêS ú&ıÆã„'u§+{íM8nç~µg‘\ß”ïÅôôçü²R¹ØN4¤Ö} Qô-ÕÊüP|væi66E>¸È;Ú	˜dìĞ}îÀïÒ“"YôaÚÂ‡×8Y±L™WŞ’„Ãôˆiƒ9vŸÊkLåöÍäLÏ‘(ÀxÕNUWu{‡¼)Gqš4%f£MœY†#íàû¾U¬<[‘´+¶Ø+ZÄ¹Sf<oºo%ÓÛ†]‘¬ó²2åT”çT»ékî@
+ÌıìÆ°c‹àK?y‘ã¢JË\8ê»+-íƒã5äj2¹›ÌÈˆ.c~Ú¯*•" Fæ)(i)ä‚Aé{õÖ£º'†1dùdÌN	Œò½ª2¹g-SƒÊ“tâh"¿ÕÌ‡(¯·k˜fF.>QÍÓ5gh“'ğĞõù—çİn#g>¦cù‚Šlg™«¼Ò¬6ªM8rQm’[ÌhMmóÅæî´×WdlZ³Ÿ¿€…Ü™üjnØTÓ­mÄÁBvc‡ZC¶^¦\rCV¢æ.ÊÉI‹Áàbvç¹³şİ×¬c=ûö_AAÀÛûßÃ‘3¹xöj‚7]ìç»À„¿›„àÂä¸ ÖòßØüáê¨‚G^VS"À²²r„»nÄÏŞş
+~½ô-•e0‡¥liTtb®&­¾@®–•éYÈ=ùºÅF,:F«‹%â`Ëq¸UßŒé‡‚—ªñÒ?=Ö“_ qìº¯ÔÂÚe=c<$1ˆµ"5w¡0zÍxl%;2»¢› §ÿZƒl'·’Q1[©m¢A(ï1ª	ãñj7ˆŞK2t`2¼ÕËï“XE£¾1ìãğ}{\”2L5ĞÏZ¨ÊÛÖ:ÄÓ‘ú8]N'ÜEŸ’æ¥ˆ0(ìs§®J”ï´©¥Ü”«­kH-Dé¶êKÛ¸  „ó3e:«øØYFö?`‹Zû¬
+<Y€¥–‚‘T-ÓU^\¾á=%¹| W¶P>Êåêâü%:•^~=‘¤<b(>ûdzÇ¨ƒ`lŸ%Qª”jL­2˜U²î¤pÒ@¥SÕ²y\dUDßTùjQÚ:Å@.ª‘ª®öıp¼Ì h0å"Õ­ô$––"úJY2±Ğˆõ&³@B@&]ËÒ²y_IÚè[-Œ–»LğHÂÿúNÇ³„E!3Š±÷-I˜‚Al
+x¼r³êBs;ñq×ñúCÀ{fÏ¬%ìJ«ÎfT’uJz¸†Ğí>øöÎ¢„5Ä²àˆÉ/£pÁOğ°÷ÿH>]í¦/	 æ*´ù+ü[Î	êcmnPk”ø†¸ioïÒŠõ‹œ[ÑQi¬ÀÊtéqìåÌJv(RÍÔ‘ÎêaùD˜ş~QîÀ
+endstream
+endobj
+
+95 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /AJYPHO+LibertinusSerif-Italic-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [96 0 R]
+  /ToUnicode 99 0 R
+>>
+endobj
+
+96 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /AJYPHO+LibertinusSerif-Italic
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 98 0 R
+  /DW 0
+  /W [0 0 500 1 1 307 2 2 357 3 3 486 4 4 518 5 5 353 6 6 314 7 7 447 8 8 783 9 9 401 10 10 489 11 11 544 12 12 519 13 13 276 14 14 250 15 15 521 16 16 503.00003 17 17 519 18 18 628 19 19 475 20 20 219]
+>>
+endobj
+
+97 0 obj
+<<
+  /Length 11
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿ ö÷
+endstream
+endobj
+
+98 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /AJYPHO+LibertinusSerif-Italic
+  /Flags 131142
+  /FontBBox [-78 -238 786 700]
+  /ItalicAngle -12
+  /Ascent 894
+  /Descent -246
+  /CapHeight 645
+  /StemV 95.4
+  /CIDSet 97 0 R
+  /FontFile3 100 0 R
+>>
+endobj
+
+99 0 obj
+<<
+  /Length 886
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+20 beginbfchar
+<0001> <0074>
+<0002> <0072>
+<0003> <0061>
+<0004> <006E>
+<0005> <0073>
+<0006> <0066>
+<0007> <006F>
+<0008> <006D>
+<0009> <0065>
+<000A> <0064>
+<000B> <0054>
+<000C> <0068>
+<000D> <0069>
+<000E> <0020>
+<000F> <0075>
+<0010> <0079>
+<0011> <004C>
+<0012> <0058>
+<0013> <0078>
+<0014> <002E>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+100 0 obj
+<<
+  /Length 2935
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ…UytuŸP&ˆ:fmgd¦úª«î–Ü]]*¢•KxT¤ô
+ôLÓ&Mz%3™I2“c&g›Ş÷}Ñi=XäQWKê®ˆ¢.îÛUŞoÜa_÷¥x Ï·ûÏo~Ç¼ïû~>ßÏ÷ó•A³gC2™ìÎgr2²‹õ9…†’-ÙÅ9šÅëõéù9™Ñ§'DL¼Ë¥ÄÅEJŸ.×ÍU9ç®Ïª¤3wÅaÿ^/‚ èµÛAìÎ…‹ hzZyOôjZ™ı å½PŒL&WmX“¥ÍÈ^Ÿ•]¨ÏÑ—%k‹ÊŠsöìÕ'ü¸[öPÒ²ÅËZ¶<aëŞì„³JØX¬ÍÍÎÔ'¬1è÷j‹K–@Ğ,H!–°øX¸±öjõÙpoH.Y«çXjÄ5?Ü($K`.>/F£±(çº”ó#ó&æ‹o¨c A:Šï·ËåÂ‰fº2º¼©£ÁŸ…Ş¥Ê®ÌêŠ¹-æÈlN€)ùRùñ9&ÅmŠŠ±¹»ç~=µR¥\œâ:(şı ÌuPL<ãš-²ßn¼ÁÊ/üWƒU  VIø†\<¤î¤è	”ƒÀÌ|Ã?GÚ	«¥è\•«$?u"«TLŒÄşóC¤¤ˆkÔÛX““¡9:ŞÉ²åx¿#O‘:`&É7¡{©¾ñ·öŸÄ‘}a–ñY°í/–QKyj‚|s`8êákòo°“(î—‡Æa¡)ØSƒ6Ğ¡¼=]
+WI»«KÁWÿZ÷Îôô»$4=HB.cì'àªtÜ÷û)äĞu`FœÁHp¨­³†ÌyŒm'øÚCú¬
+Ä7ÊÂ5NŸ•B­®*F‹o•<°½”.«@+‚dÏû@$„÷€¹0Òúñ«G¯¶a!¯ñÈ1Ú6×b]=]-•9²cÓ³KÒÕcÔ0İGc'/€?L"çÅ%â:5_dæ3±é^)IJÚ~ô£ÃG|r‚ğpæt˜Ñ³FjòëOëÄƒv»ßŒiŠLÆZ=5A_·ĞD ãçÀi˜±¹9_æ,wV
+ŠR®:)uÕÃyX5zôúXñYK+ci"\ÔİÅpÕî™²ÄŸø	=_ƒß€?DRÄu`züF4!o[#z¢¨9kûîR	ZŠ;İ|FRÂû‚êĞZÚoÎÛicvâÈ¶›¤²q7£ÙJ›ßeÌHShE5Ù?â	â#à0¢¹têÈña¬¥Öo±i-‘--‡é<k†	5UWõ¾úêàñ—q„²¶@V +4RÃzk$%èmõuâ*)‹‘¸ıôGÄ€Ç)uüÚñ×ß¥èå¥oÍTc:Ô<| £.åñ¾AÛ‰uë‡·=»|Û†”ÌÖİgÒˆÃ{¹¥èÖLÓ.]•·•ÅÛØªŞ¬.!5/kÎ9•ä’¬âg‘¢.@ÄşI¼†œETm”ääsÔcæLÒŠ=›å¤Ñ\‰U9ü!¶šš˜Öj*7´—¼½¬ù@Ñiˆ€Íõ“õë>ââ®ÊƒuBÀC ã.o‹å9GÎK³äÕÇü#Õƒ5]ñ';ö76`mÕöR/aEƒXŸ¿=4š6¸V›R™šNìÍĞ­*[¾»ÙLŠ[šI%É©}âí²É) ›Š™+ÕÛÂÒ|€ô÷	u=øÇco_óĞ÷Ê®H·K<*%IJ|* ¾÷]ï­¯ĞÖá5Å¼¦ Í´­ĞlÁwk3Ë²±Âİ#ß*PüKªw€À’ó×.VG2Hğ4x_½ùÇ²Éşnl$„‚0€'ôcÍ>¦Àâ,aò‰¤´[üNI0˜ÿ×H_?Öb
+Hg!O ™P–”St†56šké¹4ˆ#íPc¼f,»D[T†Ù9ŸWğtğÕ¢!_OÀ¾6¡¯	=UĞ¿vkÊã›p¾ŞİFß)hĞ&?½mõFœs{¢j&C‘p¤á¦œwÍxÀ6ògzF2H+[eÓâ*i9uü»O656‹€Ô tĞ51u^´CÿZ²ôx²´JBV>5uöÍ¡‰ãxµİæµ`›6ë­/`»òÛ?õºZÜl«ÕI÷ä®¦ppÏĞ‘—°á°µP%S/‹1Ã`W_}ÈeŒ½x<2‰œ×€BÍè`[‰Ãôÿ-áº˜	#Ô	ºP?Ë[qäÓ"*ÙœÁ²%q¬›ğ>l’+·ô$ì”÷Z
+;²±i‘t¿”´µvÙe9{è•ÑË'~B”ºùÉ,,yãèõÀ¯?éØ¾W_şbá6BUÎMC8	MÏZCB‘°1Äˆ/!ç@Ù·ñjdŸ®4(”È9sªEkØ¦°Â\;ÓÓÑ|;'ø¨B;ñÛ›¶²*ÃŸÏ:\…`w»##ãÎ1e"/ğÍ¬7‡ËâÉ°¯÷±2nĞb¯ËÕéj BWÔö‘Ç¸QrÎk¦÷`ªôï¤ú=bÒ‡ˆ¬}OµŸK§ÎÌ˜-¿Š3Ñ9?7Ÿñóéû¹ùÌ8õÅ[\q{éİKñ7A;|+ÙÅÿƒlIvÃr‹æqD3#{B%DS–~h­ë_Æ‚¹à{úKd'àÀ_ÔÁHÍOušÿı¬ÊıqVqÑYµSÊ€™<ê;H8²s4ü2*d‡[Ü¬Öµ:;[[;;­:Á ÃUÒiU&u\:mtå‡`å$²OäÁ7j¡1Ø[ƒ6P¡¼lOZ6…J³`)vMêÚX™%ÔUïiñwÀÃp ?¼¿	m²Õ¼°9gã‹8rŞÊûèZ¬·s 9„ùy»Åj30:"Mzft¬Á„nî×M<ùõ»8Ï‘Y°5¢ğ_˜_ Ú$™ßL¹š\*~>Íµñ0ˆ¿–ü²\ÿUS?PçºßRÔÕ£İæ¦¬Ârs‰ÍCñY\§÷•V iå<»¶?\¬ÁŞÌç`Aüá*sK1¦_“¡ÛK ÕnR°h…¯f ¾‡X«—h_…·¬ïŞ^ÉaÑ)ÊHO«Â(SØk#cĞXi±1?wÌÚpøÂ™¯Nªt×4t	MO_&¡XàŸ–ı9Zqœ„b›Es'ÔvmEU†#ŸCL7{BávG0&ï¼Ì¹ˆº£­ÇZÙ|â)Ú×=I³ä%æÚ6Á%¸½Äç¢Ş×]W»_ˆïãÁSïÆïrîqfeïr§)Ykäíƒl\„­6Û
+ª³\x¹G¶úc ú-¬v:¼Î §ˆVÏvÓİ›®Iéq>+ÏĞœ“ãP§ÍfehéQé¹¸¢‚ô´-¬ÂfçìNÂa„¹9=îvw÷H‡s\™È{„f˜wñv7^æË=Œ7€ƒÕ¡0V‚õp à÷y0A`i¸"m„ıU‚Õ†RVVÏáFvp¬#“çàq÷awkë¨3¢LôÌÄt
+v<×˜"	@g«fƒËíA=A_°º,ëâ†»ºßğ('„fÎg9sC;K™Èq#lwòœ€uspØéuØP†¶˜«pi™”ÓŒİÁb+øÄ#`-l«q„ühĞçmpãıØÃ{¼n‚o‚.ŞEìr¦:õúlw¶2‘eaÕ
+êµÔÓ&¶–Š³¦VO<sÊeŒ9d!	òÀIõğ0²†\,áp%E:Œ&=M w“‚•òP˜¡¢Â ²´¶×#ŞùÇˆ¤‚3Ã¡ŠAlh¬éPXIGĞ =Š\™&1+n§‰çÁŠ	0n«oüX Ì2A‰#mşzG«mlnë(ªÓïÈ-_›JìHÖ^†•“Í?Húò4,$Ú_á+S¨¤/Èë²S Š¿PïÑåéšC]ı½Æ&¡ú/UèHk
+endstream
+endobj
+
+101 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /CCUQKU+DejaVuSansMono
+  /Encoding /Identity-H
+  /DescendantFonts [102 0 R]
+  /ToUnicode 105 0 R
+>>
+endobj
+
+102 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /CCUQKU+DejaVuSansMono
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 104 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 30 602.0508]
+>>
+endobj
+
+103 0 obj
+<<
+  /Length 12
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿ? 	ùü
+endstream
+endobj
+
+104 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /CCUQKU+DejaVuSansMono
+  /Flags 131077
+  /FontBBox [27.832031 -214.84375 598.14453 765.1367]
+  /ItalicAngle 0
+  /Ascent 759.7656
+  /Descent -240.23438
+  /CapHeight 759.7656
+  /StemV 95.4
+  /CIDSet 103 0 R
+  /FontFile2 106 0 R
+>>
+endobj
+
+105 0 obj
+<<
+  /Length 1026
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+30 beginbfchar
+<0001> <0066>
+<0002> <0075>
+<0003> <006E>
+<0004> <0063>
+<0005> <0074>
+<0006> <0069>
+<0007> <006F>
+<0008> <0020>
+<0009> <006D>
+<000A> <0065>
+<000B> <0061>
+<000C> <0072>
+<000D> <0070>
+<000E> <0068>
+<000F> <0073>
+<0010> <0028>
+<0011> <0067>
+<0012> <002C>
+<0013> <0029>
+<0014> <007B>
+<0015> <002E>
+<0016> <003D>
+<0017> <0027>
+<0018> <0047>
+<0019> <0026>
+<001A> <006C>
+<001B> <004B>
+<001C> <006B>
+<001D> <003B>
+<001E> <007D>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+106 0 obj
+<<
+  /Length 7384
+  /Filter /FlateDecode
+>>
+stream
+xœİzXT×¹ö»ö·×`fî‚1ÊM^¯D¼ F+rñŠPC­¦ÖBrLñÛRk­±i'M	Æ”ZÅ\jR¤iRk<š¤¦›“s·çYkÏp1&íó÷ÿŸó<?óÌÌ¾¬õ}ßû~×=
+ ›AÈ(¿·Şuu·É
+ày@É¨ª]^½HY}P< \¾fCÕ–‡bN´°›WT–U˜nâ"àl0jÅŠÊ2s‡¢Î7 Ü±¢ºş>Gu;àôp¯©)/ß”»'Î«Ëî«å§Õd ì[ \kËª+/¥  l?öpmM]½òı`iíºÊÚ1/0Ã› S:pF¾°GÑ* Ø¦l‚ÒûêÀ)œ"×u°3l;{gp^œÁ|ÄèE6[Ğ	 TÇ´`¿ÜÙBï¡Çkxo¡Şc9ôÎ°×Ï.¢Ûû´P'¶ãu¢‘:©”fÕ8ÈĞˆVƒMJ#:”ÙhÁ«ê9 ¯b¶a¢¯JË¶°GqÏ`'z°G¹Š…xÏá´Á†ÖëØ¤QÆ+UØ‰ÓhÁ>ìc[Ğ:, :.ñne8âì°ûy7ß#øàİ¼›ˆƒ bµÍiJd¯IŞ±çÙe&^chÄº‡¾Io±­j¢º®¢E-Å*œåİš-¦D´hUlƒºT¾>e½º”ÁUÍiZFŸ¢Q‰Çiì—ˆg”Ù|&Ÿ©Cöc¿ül1>5^¥Ï±*:›¢ÒD´ Q=8  5 j(«PƒFŞl¼pGÊ›©Ui4Ø`YÊxìWªØN´(×ñ*j(£Q…X~[Ù3š0mDïœxÖ¤q•†—í¨’TTqÔ}w©ë¥ñ©)·œºl&×QÚàê¸y³¸TáòAG)É|TMJ¼ôU7/¥¦L+.uu°ˆ‚|ŸØ‚¥ù©)ÓJJ*Iâ,A||jJA¾¼'´åIGyRÑÒ£®ò®¶‰cvØ*Ç¤BÁ
+½U]Á‚`Âàç¡2' 9Û™™oQT¤w÷Œ€í¼ç¼'#ÔoOŠ·Ç¯Pá­£ï;z«)øÓÖiw Ã)@MÖœÅHw4·1«¹]cMx<X; „š`áZPH Óv~\—w\WfNÎ¤_Éôzl×299,,1A‹eñañöD{|v|öÈQYjò¹òì}S‡ŞÍ†?ñÍ¹÷îåå-Şt:×2³ã)ŸŞ›—Õu	B‘â´ˆiMö½ì¤5È¢NU4:m=¯'SjìñØ#rr2BíYvgxVæ¨l{–=1;˜%&9Õ±ºö;;ñÄ7Ÿ<Ì+í7¦î~øÙŸ)¾8p¸¬âRÎµñ}Ö“LÑ0Uè”ú2½HwÅ§Ùí#‡$&haöD{VØ–•®Æ[õÍvvtŒ8\÷³'„:¥](¼±M]zxiù¥^|Ij#¢î¶î:aÃÎ¨áMdk²tÒŞèP‡Za´­§+SøêJÇ¦÷\³}|-#)˜%º`·!>3<",	åòh5iê÷gë^ı-–ÄÔ»÷Í,ÚµøçÏréÜœáÃÙ]ÌÉœì®a)¿Éóö½4v‚°c šùŠîÈ`n¡vØÙIs{€9Ğ¢¨ĞlàŞõôŒëòdÚ%xáWgøXáå!ÙÂ¿v¥ŠĞ—,i8{éìá^şıdË¶o-ÛuèŒ²´…M€‚§5_sÂ‚ ¤¹£Ìí°v<“šÒ®Òô@¦ñé˜`
+¶wÅã'÷d^1•Áâ…Îìx{<Ë
+Kd``ÕŞµ¬Z¿Äwt¨K½é--”§Lº
+(Ø~ó²:EmD "èÕšh²v:öFZ!ùä›)ÈGïµæg2{ääL‡İ¦$&(v›CYÑôÈ#MÍ<Ò|õ“ëï_½~.¾ùz÷[ou¿şæ~ı÷úé—ô×X*ÌâXšà´PkÔF$àÇîäHGˆE5!6F3…Y›\Ôs2Êf‚=Ä<C›iŸ2sPäŒè‚D[Ï´£Ö9ÓÚç,*=†è›'îZàçõx=v‡ }Ü¸+=ãëöœ{DN†{r†šÁ3´S†9Ã’81|bÄÄÈ‰Q£'ÆL41vbÜfÚ¬næ›µÍ¦ÍæÍ–Í›[Â["Z"[¢Z¢[bZµÄ¶Ä%²ÅLmëÈ·F´r0aåÔm5‡³‹ÇÎ™Z”óÓŸÆ—Oœ^I×¦œÓ/ŞX¯<ğA]ã;76)|X+¾Õ¥KÇM,>h¼yY-U†A(pA8±€–f-¼iMAì7QM¡A{cId³„k(ä°M‰•né²;D¼	ß\±]³]³õ\säØEI‰÷Å{˜?²2&™&µÔ{ù×O•¨^yj‘ş…ş&s}øú'ê£m}Ò¦,Y¨=ûÒ]9ÏÎrX(³2·şçÓ8*úöÖ›—ÕD+wb­{X€	Ñ.kdˆ	í‘¦&GüN×¯c›î±Ä"Õ¨à ÍšïRµ°	Ãl=.¯'S$Ä¤w]éñŠX²]®räØ9îØŒÁ®ŒøŒ„6´±6¥- -ğ@x[D[d[T[tğâ~œ=Ú_´²GË²PÙÒ	qLéÿ£ß¿fÏSìØ±±¿Øü³W¾øû'ìÁ]KN,ª:^ºóôø!.%ë›µ•µ¯=wçôªøÆo?ûà†Q#;’“gÏÎÜ%k[¨[ÔFØ1Ëª™	vÚÜi9i
+Ğ4˜¶ó]FUíñœEàÈp'Ù`c6».æ²g ƒeÙ2ìn¸Ù$›Û^ŒbVl+¶;3£õEN„ºeìıEO¶;–öë-ù÷¢iÃŞxåÆkêÒ·ÖoJ¸CØ£ SŸ§ÎQaÃ d¹q8£›‚MæÎà½ìŒµ;'G¨Ğ”B™²Û®\‘I+êPR¯>#g‡0#€%§lı±ci{+Î¼÷—ßVíenÛúànİÖ|ãe- ¥d¾ş‚ş¾ş7ıåùìã×ß|«ûüŸŞì×dßØ¿}?ğÜ¶ØÿA?Ğœ7Ê†ÀĞ}ó²ª©HFƒÛdU‚#Ç™-Š) "np\^l\d@`Ü`5;Ù	Õ¹3ìDd“]mJê´ï88Æ„Y1Zp‘Is&µõty¼+"ü)dÓ?İÃ!CrZI©Éü="Ç$?$°ŞN"ÊX˜SKL’œÇd5LWÒ˜èÜ™áôê¬¶’÷<;u{³ç÷%í«–??çş?6üğßŞüíÂCjÎ3iiw—L›š½ã¡ã‰‰ÙÙå6P‚ïÚô£—ñwDÿˆ4‚0Ø¢íÇãÁA&CCd@°í¼'Ó#sÉæõd0M	s:"‡(Ù#£©aë–-[Ûv?öØnÍqEûî;ú˜w¯±So_d]Qkô)ªÃ—ÃSÜÉQÖ¸˜d9v††[šâÂ›B¨éÎ¸SCOK‚f¬9ñS†defÊ˜ê2’×Ö}M'›\¿X
+u*}´ŒWD¢Šş â<;‹n{`ÛÃ-mÚÖqí½é‡J–µMúŞC){ª»Ş¿kMkz‡’sö8{öoê¼ºwPL{ZÊ£æKîac˜‰™Ù˜y5òs—~Iùˆ¥ƒ#ÒH?ÆTMLl¯øˆÉ
+£ÄPvİ{z_9K?«?À6{ïÑ?¢d?·&Á­‰š©:ƒmç½²qûE„;ÂœŠ)q”#{¤Âî‘¼¶mİ²Esxôq/éã<a/\¾Â^ñyAšz4'î@•;;*$,PK²DÛÂb¹+ØnA;{ÁòbX{è/“¬– ~Gxbx¨â„+j|@Oê"ì².Ê·4E&²#B”ËŞ›\ÌãÙÈ!ÃY¶`›‰‚hL“NÍÇb™3<‹zÜŸ=±ºiÂ„æUO|æ.lš»hmÍÂ¹M<váo»ë[Öµ~xaWËü‡?ışÃQ1ïÿ´eäHï° ØÚq@a±Pmb"N¤ØÙU¯—ĞÏÊÚTÊ–ªè€œ¥cÜVµMSÚ`æL…Y Êì£Å(_ªÆqQ¼ë“JŞ¡O±Ñ¥“wƒàx–á!ªb(´õtÉŠ¡t>Å»oˆ‡0Y{ªn^V‹ù‡ˆÅ8w|T4Â)z÷ ğİôëÓ¶İ–VÚgÅ¨ĞL-;Îæõx»¼]Fš‹D?/b×s›AÑÖQ¢ÉÄ«ÅwŸ¹W¿¢w17‹]òdñİG¾qúô¯_˜TyçÙ¾Æi3ØnVÃÖ²½Ù£ÎÎ(ÒÏê¿Ó_Ö»Ç³GI^rn^VOó1£ñ÷2»Mq„DXƒ¬ÁAAÖÔ%mx2³Ffâ#FG0†¼ÑV‹Æ¸)dDP$†S‚iÄnGB|Òî¸VÇ^S†2“FñV³:zx|äĞ˜x5Ô<Ôc²Å¤9Âî²ıÉÓåí²½`´V¨ˆz&úîW®_{ıw¶kv£À‰©_óñÄ[Ö;›À²G¦³¬0§fŠHL¹Œì‘£Fû+]ßhm
+f¾ö<VY[òb§N;Ò=³ä¹UoèïîØ™™ñâÏs·İXPV;fÔ=‹^z|Ø=)1‰6ÚyãÜˆÖ®BSòş^úNua>zeûûSvLn}*2âÙä¤E3Æ>p¶èÇ÷ì~12"$"Hú¿P´ÁÂw¨Ğn=Míœ4Zàt‹¨‘ŞWŒYÜ+je0ƒ+›-øÃÕŸüRÿ#»ÈZ¿õíıçOÒg€a; ¾Ì»ˆİîxs’ÅÌ5nJÒx™+Dx&@3s•4faqÈ°Ú¼LÛ‰9}z2}„
+Í,HxÚ¬2¶Ø=İÄÃy„yb¥*s•ùæRK…r?ß`n´+ÄT‡¦˜Ä¢d¢71¡"š¬M6-¢ù¼T+5Í7¯¦ûé>SÄb,Í²³,Kd&{âö3ÊúnWæõèQûÎğî+”=7~àmV<otH<€ú´æD N»Ç˜#<šÆ-¤˜#LfRx„ÆRÔ"Å€yûpZ˜¦å£Àjëñx2í> Wü‘c 5™?0©2jü¸M÷lM1›Ã•HiÎVFòQæB¥JiPîåV™ÍQ¡Fò(-ÚiJÉ|¨i,UGóÓhóT*2-Ğ˜VÓJu¥¶Ò´îã´¦A· ÷t²Ëoë“™~I_¶½SszÙ9}áB%ï}"£G¨Éà° Éj> ÉFñd ©ˆe¦X-ÀvŞ{Ş+û…ïÑI¶N¶ ¯××9èEıÜÀ¿Ê=zpRL¸5Ä¢r!ª=í‰/Ä¼ÒnÿeÒ ¨è°Q£Ã*¢‡·!P•U>Ó;Nï_UçÖj$pF„¯¸Nc½Õ>\÷¾j?œ]Èo·°fí¢yÍù>;¼ºÙín^}ø³	¥ÍŸî8&êáïÚ\Ú²ëÂ‡­ëZêwÿíÂcF”%ÛŞİsü!ã>Æ`³¸Š×NÿÔÿıÅŒwšs 7}ûLÕz, ûbÇM'ï”’úÿ1õVà”ïµO‹ÌB5±•­B'N¡›A#ÛÅîÁv¥ŠUÈA¶ÃÃvá€!X†}ø=gÅì»ì;¡*ûÈF¥t€ŞT‹Õo©o«:Æá‡øKüm-S{Ûd5Õ›>22WZ4X±b8VCƒö
+|>³ƒC•¿Ìî ©@şFi3¸Ğé;V`ÆŸ}ÇÔïºÚï˜#ïú5‚î;6#Eû1†ó…a÷úƒ±Â¹“PƒZlÀ:¬Är¬@=\ŠrÜ	2‘dÁ…eØ ò°õ¨C=Ö¡e¨F
+\(ÂZ”#.äbÖÀ…Ù½²êäY%êP‰u¸•¨@J¬Bæ¡.”cÊ°ËåJÊ¤|Vb-\¨E–aV¢.T Õ(“÷n•S"¥	3Pƒµ¨AjPƒÕ˜'õ×a¥¼.¥!£ì÷ïöï(»J^5ÕûĞ„õ¨Å¤#¾õ÷¢i¨C°å¨”{×ItiX‹JÔ£°Ÿ4?Z?ë_fYÜŠUËP‰5¨ÁzÜ)9ÿ¿Ã¤ğIÀm5Ì•Á5Àæ/GM Rÿ…—Ğş¿‰®€y¥EásqEøXp¶«áBªş¡-Y±”W-¥õÅ !{…¼WéÃµ\j,û„œ*y·²W›áa#šÄızÔH×Êıµ¾874Ô`ê}ïå>,å>¦ı2ë¥c¼år]5j}ÒıÄjÃv#’*eÖœĞ/J¤çÄŞ
+ù-°× +QæÃgÄ`9P-¥[ë{ù©ÂJ¬ñÅñĞ^û4ˆ|ö×c½/Î…Æ>NÄ•Z¬C*Ğ íì³¦B"[‰ehöôñğÕ„tÁC9Ö AJ18Y/c`…Ìùz3Âßùå÷Ex]¯µ’Ã”~ŞÇ‚—>_÷åoVÈ+·Ã‘Ò‹3]Ö—”läƒ!{¥ÕŞÿzÔ~æk83Œº>Dë%Õÿ”6TÉš¹Ö‡ĞˆCšˆ¤FZS'™X…J”KyÆšşq¼ÆW%ıÈ‚•½ş¨Ã™s|»Ê°5²2ôù -êcàË•@ô!WDYİ€µş\©½mè¿O ¹mxJÔù±f°aTò²¯ñ§lÔáûjùİW?ş_Ôcƒ´·JV!;m S_·Wp²¡×~¡]p.rÙ_Ñ„í"N×õ^1,œúQ
+ö:ÿZ¾°Fõ!{³Ë}Qhà]5Í
+ßµuıj¨@gXR×«ãV~êş!¦ş5®b@„	¤··àë-¨ïV^ng£ÁâZ©I ùêªnxI|
+ûªÈõ_©ëLŞÜÚE*}õNXÜ§i½DU!÷'Ü¦/&ôâ¾u‡Xïïº	ı¢ÍÈé·ôÁ‹Ñ›ü¶ŠhXÓÏ÷¢+oÃX%î“<Ñ[†ZÔúº˜È~Ñmü;úûß°ùë3FøQÜßu>…¯‹İíj¸¸Û Wd8ákç•„>ü?ÍYQc×ôöì¾¬óg”˜ ŒÜ}Éè/·J{Ê±erlôEU_?ş_T¬¯FeLZ‹¢/Võ25RÏ,ÌÄ©g
+1ó‘‹Ùò^JàB1fcæ¡ù(@¾ôK®¼#î'Èlœ")qæJY†ŒÙÈ•²À%e‹Iu¦<›†"ÌD¾Ü[€R©£ %Rê,Ì–²g ÓQ$u3æLLÂtÌE¾<,§QCßLÌ’ßbıi‹aéÌê§u UBrI¯e3P€Ù˜„)¾»¹ÈC‘”'ìúåñÌ^;}–æJ„d!sæbº<Wçb6Š1%’O!9ßgíL‰¡³}X
+¤†'‹&aŠ±@®˜Œ)˜#­šæøVŠó9ğÌ©uš¼jX6ËçeqÜ'E<†‚ÿy½šK$şé˜.¹xK¤†äbF¯\ìL–„İs%>a_‘D(dˆ{‚EÁçôŞ•³ûyEø4WúMX.ö$‚‘’Û"ñKèÛE‡_ƒ%ü&˜š.W— ˜$%WŒx,’X'ù¸5dqoÄ„±Ö°Iøg¦ôìİ˜ë[aÈ»…‘!Âş>†r}Ÿ“úqÖç}!QØì·GD³ˆ²/³"òOX"V‰(g~DŒ	/–ùbèğûq®/>ı™7ó~ıyä_÷ÏÔC–_÷@
+>O†…F%™ùOÉ5jWî“u¯Ö××ê¾Ô¹ûO}Siÿù3¥_­í?	Ux²\[}Ëº¾«F}6zVß3OÿîvËÿ”œrËôëŸ>ŒÚm<õŸ~+äœnÌ‚u½S‰Ñ?jz'1ıƒÿ©E<Šş2ğy¯Nê5º¾,Ë˜/Å:C[İmØüºuë¢°Ep$$¯—Çâ·$cb(“kÄZqış[Šÿ¼üXşÿâjì¢b])ódšOîºŞç³>NÆ¯[Õ·x½/ú„´1_šCËûY.ïŒCÌBgÀ¿ğûZºä{5V"]Ú(öŞ‡49…×"ı–‰Rü{™ü»ùm,ôı2=ğo0€"”ânb>¦c6Å˜‚|Y¦a1!°b	ìÒöa°`Ò0qXzLÙÌÂ~l1ÏÄÂĞ
+baØ,ÿßŸb¡òÓˆÙå±M~†`ˆËã §ÿ:™ç&± l1+’@,™  åYä*3‚AÌ$5¹†ËcU^'yE‘W˜{NºN76’W§/tú<“>;NŸn¤O®7ñOtúä„zıãüz]ß¬~Ü3„¼€>v«=Cèï¥ó¿N¥Óëô¡NË¤kNú •<Ì=:y:nsßTÿ:™Ş¿ZÁßo¥«ôŞ{7†¿§Ó»1ôNWVÓeşë8]z;Š_úœŞ¢‹­ôg.èô§·ÂøŸtz+ŒŞl¥?¾Æÿ¨ÓÍü0úÃFz}u7òî1t^§×~À_Óé÷tN§ÿÔéì;?;ˆ~N¯êôJ+Ù™ÄÏèô[^ŞH/éô¢N/ètz_ïÒé”N'uúN'šù	'ıÚJ¿:Î;uúÕó‹ù¯Ó¯6«ÏOâÏ/¦çİêñ$zN§c­ÔÑ’ËŸÕ©½%—·N¿ÜÄŸÑéôtıG0uĞ¿ëô”î¾A?×éI~æ #:=q8˜?‘I‡ƒé§‡ìü§Cé~r0•ÿd#L¥ët@§éÔöÃ(ŞVA?üÿ0Š~`£ïĞ~ßÄ×i_íİ“Æ÷ê´'v·äòİ­Ôú½ã¼U§ï=¶˜ï8}o³úØ#Iü±Åô˜[İ¥Ó¿éôè#IüÑãôHµìLâ-¹ôps ØIÍÔ´3‰7UĞÎv¾3‰vØi»Né´M§·Úùƒ:mµÓwuÚ¢Ówìyü;%ô€N›ï£MßŞÈ7éôí´1¾¥Sc0İ¯ÓzîÕ©¡ŞÊB¨¡ƒÁı¦Zo¥újƒêÜê:¾©S­N5kKxM+­­Ê×–PõPZ£ÓêLZ¥ÓÊLZñ9-?NU:UêT¡Sù²8^®Ó2Øø²8*Ói©NßĞiÉÂ@¾$˜WĞ=/Ñ¢…|‘“ÒJ4_§y:Í‰âs3iN%:ÍÖéîT¬Ó,'ÍÔiKå3tš~œ¦¥©E‘|êh*šäàE‘4¥ ’OÑiò$Ÿ\A…‘¼ğ8DRş$ÏM“òì|’ƒ&u(n·EÍËáyvÊëPà¶¨¹î`B¹ì„Û¢º'Z¹;˜Ül³Û¢N´ZøD+Mì`nw…:A§ñ,•ÿœÆé4v(Ñ)ÇÇs*è®Ñü®i4Z§Q©N>J§ìi42#šœFYÑ<K§L{ÏÔiDª“ˆ¦ŒhJOuòôHJ³„ó´ã”šÊS”Ú¡µ)6;O	¥an«:|X®Ó0K8–Dw*cø:Õ)Y§!!”Ç“
+èJÔ)!$„'èïJåñÉ•Jƒ§Qœ=Çé«Ó ˜(>H§ØxLEë¥S¤Náy<¢ÂÃRyx…9m<,•œ6
+…‡:ÉaÏãì,•ÛóÈÂmv²Ü…[yH…Üğ`+ÜY-<(€‚:˜ûÕj!«ˆ­Ñj N–p “%œÌ62é¤±T®éÄDÊNŸ“ÂR¹2†lœ¥lÄ:XÅÖf6üÿŸ?üoğ/şÅâ æ|µ
+endstream
+endobj
+
+107 0 obj
+[/ICCBased 109 0 R]
+endobj
+
+108 0 obj
+[/ICCBased 110 0 R]
+endobj
+
+109 0 obj
+<<
+  /Length 258
+  /N 1
+  /Range [0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœu±JÃPFOŒµUªv¬DœD@¤`]\Ú
+F§ëMkŠIˆ¹‘RŸB|êê&Ø¥n‚à¤‹¸º(¸H¹rëTÅ³üË9ğ`ùÕ¨a”&åÊº»ãî:Ùl
+Œ3Å¬*ŞªnÔ ”h)™&C|>b™û°ä‹ÈëŞìçº«é»“æõAçívØıCÆ«+	ô€y')ğ
+ÌµÒ8+¤/<°ŠÀâa­RkpÂàØ´óA¾mWÓQ”IhÿãŒœ%–Álş½E5VW~ªüdµşX€ì)ôÏ´ş:×ºöôb‘ˆk#&¼_Â¤3÷0±÷ØIì
+endstream
+endobj
+
+110 0 obj
+<<
+  /Length 314
+  /N 3
+  /Range [0 1 0 1 0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vİ÷BšË¡©hˆFk	¢ÙÆú‚ !
+¢­Õ †’‹¯ZPÏò~xx^Ş—”ç¼QİŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
+ ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;Q?V.ø_îtFÀà3LËEÆK¶)y	ğëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ĞŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzçm\‡Ğ8rœÏSÇiœúµ­öşfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
+endstream
+endobj
+
+111 0 obj
+[117 0 R /XYZ 70.86614 561.8816 0]
+endobj
+
+112 0 obj
+[117 0 R /XYZ 70.86614 629.0806 0]
+endobj
+
+113 0 obj
+[117 0 R /XYZ 70.86614 755.2506 0]
+endobj
+
+114 0 obj
+[117 0 R /XYZ 70.86614 373.52863 0]
+endobj
+
+115 0 obj
+[117 0 R /XYZ 70.86614 781.0236 0]
+endobj
+
+116 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [156.82014 703.28564 192.91115 717.53064]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (http://en.wikipedia.org/wiki/Vermin)
+  >>
+  /F 4
+  /StructParent 0
+  /Contents (http://en.wikipedia.org/wiki/Vermin)
+>>
+endobj
+
+117 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 107 0 R
+      /c1 108 0 R
+    >>
+    /Font <<
+      /f0 83 0 R
+      /f1 89 0 R
+      /f2 95 0 R
+      /f3 101 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 1
+  /Tabs /S
+  /Parent 1 0 R
+  /Contents 118 0 R
+  /Annots [116 0 R]
+>>
+endobj
+
+118 0 obj
+<<
+  /Length 3577
+  /Filter /FlateDecode
+>>
+stream
+xœå]o$9ñ}~…sÜuüİmXVb÷îÄ"¡ÍÇÃ&"´A.Òı}Ô“v·]®*»§'/3én»\ß_v®>şûÓ½xóæ ÄÕ‡÷ø^¨ÃÛ·âİ÷ïÿ9h¡„¯µ”CĞNAKUpâöËáêV‰ÛŸJüt{xw}Pâúápu§„öÒ‰ë»õıéëúËá¯¯~TJı¨”¿ÍåßÄõ?\şrøáÃûÃF#ÀŒƒÔ>Ú³cço7ûù;\
+Å+ğëpü¾9~>oÜ?]é4Şp)^óûwÇÏ‡§·Z‹6,lƒÁò‹¶ÒôQ`+E,\tr´ƒ=p:d8Sz xécÔü=ƒnLùüL)e,şşDß`}µ½‰XiÈ&¡K(£¥qc.´Ğz™H^-×<?S\=æ\šF˜±rÆ7ÅS+G‹@ØB  iø ˆˆ·Ü_ÀÉ§%…áêÅK¸@Mz8Ëz†ôP/b3V »\#x¡V\¢ÿ®±0 ^" ä® 6Àp;-iÛµ¸ÛOıéÓı?Ä«¿ß_"¬îì mtèâuó¼ş˜Ñë¾µÀ€­)*éTĞö<òë9DÉ¶«I–U:*È1¨=0)^k%•RÊ*¿ò5#
+`‹¬ İßÖÍM,"’½ˆDiähT…)ı„)%wQé„’£WqT®6_<ú\¦fíúP.]\Âïÿy÷éöQ¼ûÀ€­”YÀ~ÿ‘ûãû?”tNü|pâÃô”ør°Aª8ûùğ‘Â[ÄğŒZk³¯Ï×”~ÆÃ–ò³2N—\ê¹RµiÎR}¦Q)ˆ=€ØÏCÛ[j0B¨V…ÍšŒ>ë;„–Ã˜eá\h®¡E,±”pL€XQÂ]e£Óõ2w3ˆ`CštƒÙ¥çWc›ã]'Á—‰s€{’9¥‹ÿ
+¤€Ô× ]ó·5—Â§°0äâRçd|Ì‰I	Er!
+ôÂXGª!é:1wÉdC—«æqxWu¡İ¢|	(Öiò”Úb	<”íQ¼µ^z·Ôª‚U[L|‰ü"–€QÄª'Pm‚"{™¦â¨¦XkV¬‡QªÑí‘êÚ^è$h¿j°LŒm@‚…5lj.Ú´¼rm•ŒƒêCAÃ›É5ÀÃ
+÷ÔÄM¨±¬FÑ‡VÀfÚ
+†×ß]JŒÓÃ•¾l©B×©“ì4ôjå@ÁjY(®ÜÇ0ii´@¬éxù¡1ğ’*/2TyŞ£ŠÏšüÌf~B°2Ä°Ë£€ŞÏ2/EÚ0±%¶Ê¬†“ZË©u„¯x>.kc`Tp€İlM¥@ sSˆÒÂÚš·d@]÷x1”u…~,Š”'(/pƒ³ ¥Ô¤WÃ;õ•ü…Kñ:Èc±[s8(5Ã/¦¯ó9ˆsÁkÊ›gåÍEiÕ¸CÜ
+(È¿@éò5	^j×o§_vÑ§d”’PïèéW„Q¤œ6“Óˆ²¤§ä@7Ú
+ÑÌ‰K|	ë™ÿÅiæªLÃ¶{-¼a+ùÏ•7¥1°ÒhŒF¿'¶]˜ƒŞ 
+ğî·d—P€iE/ou>!ûR±"mQ¨$VuÈ0°”æ‹Ñvªj”v8YÃÖ&»±ï µŒ£ßä0ÅPxİË9Ç(õ¨´óg5±”Â«šVY+/kf	àÃÀvQæi°’¿A…)0ÿšÅ‡ëD'1XÊü5ÚR»¥ig…œ×kéœû2c>b%#Çt>éâ°Ãã lò,whşo³'J©:"½ÄD#ìÅİÚMG/Ğ§¸-.}ÊÁ>?zË¯KÖ%ÉP‚’ÀšÒ7Ép…yvÀ„%ÈçÁK?ŠOØá•8$øy­Tf¬ÈEö’»‡;Ê$9›}2l^ßFjÏ„·xİÂÉÃ87Q™G6¦\Ù"à£Ôş&Y=«B¤pÁ§Õ,•%€	ß'®zM»‡ï{‹åH†
+T&º¨M$ón˜¸­CôØÜ»ƒŒŞUQ®*_RìˆéÅf”¿!»f»XÃ6õyçäÀ·šœÏ‰…×MĞÑä½¤×ã™`N-á—Bÿ3—ôÊ.‡È½ÅäÕÖÎhî:ßš¦ìôLı€ 0Ãš5|
+x¨•núÚAÊ¢ƒrÄW¯:÷yoºÉÍæ¶½‰ÒÄ“rmÇÕıêR\ÿ‹›ËôJ3ì›}±éDëŒS«D0(·•šyÜ”Àµû;VšN!š¡/ãk@Ø¡©Øì×NFÍ÷\ïc€e€Ó78 º¡¸CÍtR¶Ç½¹êTFÓEß±óW…ªı™Š—w¸NI÷.>‘ƒƒ­"v)ô¬İÍ®#Ë®JIoR»Ü3pkd¹õôÙ÷1+¥/ßæ,ñtCMÚğÒlW
+´Ò­Â”ÕdfŞyMÈ".A¶¬2mfµlÄêÆ µuÏ§[­æ¸uÏô€]ÛtN¢|+“Ì”‚©ğÏ¢ãA'¡é+Á4>©¼abÎf³-]¸àıædÂÊ§@é 9ãµ6éÊ2n¶~Tî¯¦ÎUşËšR TnTÚùùªß|,³€„Âís¿É-áÌ8ì2è˜®İûĞL 5„·{ìPxK-ôUˆİc€4Û:·ëÍÍÍÖ²íõ±ãát‰&•/`ğª©ƒ¨Æ´ÎŒYŸ¨ºéËV	¬òVy¤ü÷ï&n5eÄ_åXqG¹ÌÈmÉùÆ±rƒšQBå-CÎßÒô6[5`Ş/»ö2Aèo}Å :Ék"nàæÍ–M—8Í{•`@¢×oUhÜx©pĞÛM©Èğ
+ÕR½Å†Èçà‰mØàê»2N®îU?œ3á;°ê¤~ã%ÓJtúVjø?Ív°æÎ‘¹½¦xúZg7…‘ítÆHoÍ>aÜºœA™•ıÏL£ZİÂ¸µ¨Æ;ƒPXû*‘dƒÜÕŸü°®b!Ÿf.glW‰¹2p¼ÙîUt×æ˜å2èk=m5caTCÿå2kXvÙîè²éf§F©Û#² 0Ej¦cúv$ê ™èpÄîÁl–*Ø¦tFê•OWşşØÇĞdÓf{Ë$±²™¾C;~aÚ¯W†J[ $ÁôÚå{øˆ${#pŞ ‰lŸ¥V~O‰Ì~d¨»èË‡‘;É6+¾uÀ€±§é€…?E‡	l(îE®ˆÃ†rË>¨W[ù5¼{Aì[¥rTM¢+vÁ·d–tbÛÄëÅ6åˆ­HÙ!Jö¥nø
+ÉW!vc/16QÕI-Uâ°AI|¥!›³A÷yUZŒÌ&«Àµ”¶ûS6¹3òk% ºöíõ„fTÖ._>ßQ¯`»«­÷RiŞéÛzÄÙEoû‹SÜgç í«êD¸•ò¹®~ìëşYr«Ğàûe+^5ÁZzŸÕA+l¿ŸµQzvU;R¤üQ%ŒHoÉëÍÑAëdRÉg¸QÉTkV¼Ë6YªNû'Pâ £eÖj—rz¥÷¸£•±L6;šåxÚÑÓÁFz>×ÈÊèG9¥Ö7š
+$ÃàF'”pŞJï¬Zatƒ·ë­ãÛ·‡åzĞRã#¤[Vå”ñbtp2Ó4gºqûOºü|XçL÷T6¢Z&¼=¨'`>Tèú×ü³·ôÉM+2õt0Ä!µbªóèÎ§´åüRD˜8Ë"áN©%Á˜3ƒİjá¡P
+Pà@¶	@Wïñ :¶:ƒÇ£ÁÃrš.£³,á”–Ê[½‡p7ÄçJ(] ñæ‘	Ü»‚ğ÷à™4öÜÆ‹H¸§xÿ<Ş³i”|E´šêe‡ËF†Ø°òdÆ«„è)k.ç[°ºtÖX4>ïg_Ç±¯‰Zj3ÚğüK}>+çÎ÷˜ğ \bßV‚|á¸ĞÔ7©âYªŒZõ<D™\‰pnĞÒã8œ]VnfÛáÜÀÂ´´ŞiûBlÛÄØØ:ùiq›ŒFÔ.;ÜR‹©Uû0mÕPR+?Æz·ñ”Ö"÷ı€*=üîêä"ñX<ƒ	Ü¼“(ûN™Õå4ç9%Zš¸Ç|ç0Ğˆº]V2˜éœÌÿ¿H©ÛNÕídâ(tdôÊßS\ İtêñ,Ô#gÛ9PğÅ¨J„é°˜˜€JÎ7½z±ù¬R…ñåæ•ôÑ¿>µ“ÎÌôsæ¤ùtÒéP`ÛpTS©õ‹M¬Tã˜ŒÇLèütòoÚsùšQm´9Ó„ÕéãXÎè8k€Ñç=a×á×x}OWIŠ
+0,6ù¸Oªb7`ß\Š¥%1ËÓ5ÁÂbkô¬Qvƒõ-zFûyË’1Œ¹˜œ`.Ñø°,L¶ÒŞF¬cé½{GØÆ£gÉ»ŠìˆKÂw˜¼
+]Á´´Q7XFğÇƒËwlOıCU¿pQJoKÒ\ÄÀòÂîE›PŒ,/ì†"–4.½Ìßø…û@(kš• Y¶°672'¬å·™Ñ^QV…ÔÍ¯Íÿ*¡XÙ½"ÛÅ#A³<²Š7uŒöi-ÿ¦	*f¹ŒÑR;;
+­4Æí UäÿÇ‰E~7}¼-5Ær\@Õm²%6[7ëÃ&×ªŠSfˆ£@ûC¬&úÙ&S×Ï8ı;”S±_ê‹SvFÜ wÿw‚İ’ é]¬İxÿÊ´Å&
+endstream
+endobj
+
+119 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /XObject <<
+      /x0 121 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 2
+  /Parent 1 0 R
+  /Contents 120 0 R
+>>
+endobj
+
+120 0 obj
+<<
+  /Length 76
+  /Filter /FlateDecode
+>>
+stream
+xœÓ.HÌS°±áRPĞ÷uötQ0à²³Sprqæ*ä27P A##3#=3cssSC=#c3…ä\.ı
+—|®@.W_g  ¶
+endstream
+endobj
+
+121 0 obj
+<<
+  /Length 430
+  /Type /XObject
+  /Subtype /Image
+  /Filter /FlateDecode
+  /Width 70
+  /Height 20
+  /ColorSpace 107 0 R
+  /BitsPerComponent 8
+>>
+stream
+xœí’¿KAÇß‘rê)¶XØÊò8°²X‘=.	wX¨­…ŠhÄCˆ'ˆà/PÔS°DEÍÂzá”3`‚’BdıÁ..w:û•Ù¹EıÔ3¼ùÎ›Ï¼÷f€×g¾æ È›B-§œP> ÿ6i(ğÛÚ¡Œ-çX`D™K>R4çĞ¨Q‚ú —úïÙØÕVH9©úš'sI
+¬}»÷5§lÌVäöh6ğ%^	ê—•ø¥“÷Z6ÖË> øúp.7ÑlŠMÚ82†"Êü‡¢Ş-·xåHwõ?×ôO‰m4¾nÙ%Z,êqJsÚÊrSdÚoİU~R¬Pd— \v6ÑƒÖé}­ªÄÌWYÑTc€_‰'-$EûQl ÌdÃ+ß´…üçÑ°eæ¤VBÊàØxŞİÔOÀÙ¹‰(³Àq˜ævS¢m(QÂ,{*”^ L²Cï“î†”ş÷êc:Ÿ“Ì{Të˜%F”í¹-æÊ¼)îúˆø‰ìnBT»ˆ.Ô0`	(1eCI"ªQbæ¹1ß{) .VbÑï†·aqâÈÓ
+endstream
+endobj
+
+122 0 obj
+<<
+  /Creator (Typst 0.14.2)
+  /ModDate (D:20260514185418Z)
+  /CreationDate (D:20260514185418Z)
+>>
+endobj
+
+123 0 obj
+<<
+  /Length 996
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-14T18:54:18+00:00</xmp:ModifyDate><xmp:CreateDate>2026-05-14T18:54:18+00:00</xmp:CreateDate><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>8Dk/MbDdQZmyH0riEwkJEg==</xmpMM:InstanceID><xmpMM:DocumentID>8Dk/MbDdQZmyH0riEwkJEg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+124 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 123 0 R
+  /Lang (en)
+  /StructTreeRoot 8 0 R
+  /MarkInfo <<
+    /Marked true
+    /Suspects false
+  >>
+  /ViewerPreferences <<
+    /Direction /L2R
+  >>
+  /Outlines 2 0 R
+>>
+endobj
+
+xref
+0 125
+0000000000 65535 f
+0000000016 00000 n
+0000000090 00000 n
+0000000170 00000 n
+0000000295 00000 n
+0000000438 00000 n
+0000000592 00000 n
+0000000882 00000 n
+0000000988 00000 n
+0000001312 00000 n
+0000001778 00000 n
+0000001804 00000 n
+0000001992 00000 n
+0000002135 00000 n
+0000002222 00000 n
+0000002410 00000 n
+0000002505 00000 n
+0000002597 00000 n
+0000002775 00000 n
+0000002862 00000 n
+0000003040 00000 n
+0000003127 00000 n
+0000003305 00000 n
+0000003392 00000 n
+0000003484 00000 n
+0000003662 00000 n
+0000003749 00000 n
+0000003927 00000 n
+0000004014 00000 n
+0000004192 00000 n
+0000004279 00000 n
+0000004371 00000 n
+0000004549 00000 n
+0000004636 00000 n
+0000004814 00000 n
+0000004901 00000 n
+0000005079 00000 n
+0000005166 00000 n
+0000005247 00000 n
+0000005339 00000 n
+0000005543 00000 n
+0000005630 00000 n
+0000005834 00000 n
+0000005921 00000 n
+0000006125 00000 n
+0000006212 00000 n
+0000006295 00000 n
+0000006437 00000 n
+0000006524 00000 n
+0000006601 00000 n
+0000006689 00000 n
+0000006856 00000 n
+0000006943 00000 n
+0000007030 00000 n
+0000007117 00000 n
+0000007204 00000 n
+0000007291 00000 n
+0000007378 00000 n
+0000007465 00000 n
+0000007585 00000 n
+0000007690 00000 n
+0000007843 00000 n
+0000007928 00000 n
+0000008019 00000 n
+0000008108 00000 n
+0000008193 00000 n
+0000008284 00000 n
+0000008373 00000 n
+0000008458 00000 n
+0000008549 00000 n
+0000008638 00000 n
+0000008723 00000 n
+0000008814 00000 n
+0000008903 00000 n
+0000009190 00000 n
+0000009283 00000 n
+0000009422 00000 n
+0000009553 00000 n
+0000009645 00000 n
+0000009782 00000 n
+0000009936 00000 n
+0000010023 00000 n
+0000010137 00000 n
+0000010249 00000 n
+0000010428 00000 n
+0000011033 00000 n
+0000011123 00000 n
+0000011372 00000 n
+0000012591 00000 n
+0000017441 00000 n
+0000017623 00000 n
+0000018451 00000 n
+0000018541 00000 n
+0000018794 00000 n
+0000020361 00000 n
+0000027366 00000 n
+0000027547 00000 n
+0000027978 00000 n
+0000028066 00000 n
+0000028321 00000 n
+0000029287 00000 n
+0000032328 00000 n
+0000032493 00000 n
+0000032761 00000 n
+0000032851 00000 n
+0000033137 00000 n
+0000034245 00000 n
+0000041709 00000 n
+0000041747 00000 n
+0000041785 00000 n
+0000042144 00000 n
+0000042567 00000 n
+0000042620 00000 n
+0000042673 00000 n
+0000042726 00000 n
+0000042780 00000 n
+0000042833 00000 n
+0000043122 00000 n
+0000043496 00000 n
+0000047153 00000 n
+0000047386 00000 n
+0000047540 00000 n
+0000048153 00000 n
+0000048270 00000 n
+0000049356 00000 n
+trailer
+<<
+  /Size 125
+  /Root 124 0 R
+  /Info 122 0 R
+  /ID [(8Dk/MbDdQZmyH0riEwkJEg==) (8Dk/MbDdQZmyH0riEwkJEg==)]
+>>
+startxref
+49593
+%%EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,22 @@
 markdown
-python-docx
-requests
-
-latex
 jinja2
 
+# below this point all packages are optional and only needed for extra features
+
+pillow # only needed for rich backend, but not strictly required
+
+
+typst # heavyly recommended for pdf output, but not strictly required
+
+# thats all needed if you want to work with docx
+python-docx
 docxcompose
 docx-mailmerge
 
+# nice console showing
 rich
 rich-pixels
+
+
+# legacy LaTeX support. Works, but slow and cumbersome
+latex

--- a/src/pydocmaker/__init__.py
+++ b/src/pydocmaker/__init__.py
@@ -1,20 +1,25 @@
-__version__ = '2.5.5'
+__version__ = '2.6.0'
 
 from pydocmaker.core import Doc, construct, constr, buildingblocks, print_to_pdf, make_pdf_from_tex, show_pdf, is_notebook
-from pydocmaker.util import upload_report_to_redmine, bcolors, txtcolor, colors_dc
+from pydocmaker.util import upload_report_to_redmine, bcolors, txtcolor, colors_dc, _raise_missing
 
 from pydocmaker.backend.ex_docx import DocxFile, DocxFileW32, can_use_libreoffice, can_use_w32_word
 from pydocmaker.backend.ex_tex import can_run_pandoc
 
 from pydocmaker.backend.pandoc_api import pandoc_convert_file, pandoc_set_allowed
+from pydocmaker.backend.pandoc_api import config_pandoc_allowed_set, config_pandoc_allowed_get
+
 
 from pydocmaker.templating import DocTemplate, TemplateDirSource, register_new_template_dir, get_registered_template_dirs, get_available_template_ids, test_template_exists, remove_from_template_dir
 
-from latex import escape as tex_escape
+try:
+    from latex import escape as tex_escape
+except ImportError:
+    tex_escape = _raise_missing
 
 
 from pydocmaker.backend.libreoffice_api import config_libreoffice_path_get, config_libreoffice_path_set, config_libreoffice_path_find, config_libreoffice_path_testset
-from pydocmaker.core import config_pdf_engine_get, config_pdf_engine_set, config_pdf_engine_scan, config_pdf_engine_test, config_renderer_default_get, config_renderer_default_set
+from pydocmaker.core import config_pdf_engine_get, config_pdf_engine_set, config_pdf_engine_scan, config_pdf_engine_test, config_renderer_default_get, config_renderer_default_set, test_typst_installed, compile_with_typst
 from pydocmaker.backend.pdf_maker_tex import config_latex_compiler_scan, config_latex_compiler_get, config_latex_compiler_set, config_latex_compiler_testset
 
 try:
@@ -22,6 +27,8 @@ try:
     can_run_pandoc() 
 except Exception as err:
     pass
+
+
 
 
 def info_optionals(force_retest=False):
@@ -48,8 +55,37 @@ def info_optionals(force_retest=False):
         'pdf_engines_available': config_pdf_engine_scan(force_reload=False),
         'pdf_engine': config_pdf_engine_get(),
         'libreoffice_path': config_libreoffice_path_get(),
-        
+        'typst_installed': test_typst_installed()
     }
+
+
+class options:
+    """A class to hold configuration options for pydocmaker. 
+    This is just a convenient wrapper around the individual config functions in the backend modules. 
+    Each attribute is a callable that points to the corresponding config function in the backend modules. 
+    For example, options.latex_compiler_get() will call the config_latex_compiler_get() function in the pdf_maker_tex module.
+    """
+
+    latex_compiler_scan = config_latex_compiler_scan
+    latex_compiler_get = config_latex_compiler_get
+    latex_compiler_set = config_latex_compiler_set
+    latex_compiler_test = config_latex_compiler_testset
+    libreoffice_path_find = config_libreoffice_path_find
+    libreoffice_path_get = config_libreoffice_path_get
+    libreoffice_path_set = config_libreoffice_path_set
+    pdf_engine_get = config_pdf_engine_get
+    pdf_engine_set = config_pdf_engine_set
+    pdf_engine_scan = config_pdf_engine_scan
+    pdf_engine_test = config_pdf_engine_test
+    renderer_default_get = config_renderer_default_get
+    renderer_default_set = config_renderer_default_set
+    pandoc_allowed_set = config_pandoc_allowed_set
+    pandoc_allowed_get = config_pandoc_allowed_get
+    typst_installed = test_typst_installed
+
+    get_info_on_optional_components = info_optionals
+
+
 
 def pandoc_set_enabled():
     """short for pandoc_set_allowed(True), which will allow pandoc to be used as a valid conversion option"""
@@ -223,5 +259,3 @@ def mk_image(image, caption='', width=None, children=None, color='', end=None, *
         dict: A dictionary representing the image with the specified attributes.
     """
     return Doc().add_image(image, caption, width, children, color, end, **kwargs)[0]
-
-

--- a/src/pydocmaker/backend/baseformatter.py
+++ b/src/pydocmaker/backend/baseformatter.py
@@ -68,6 +68,9 @@ class BaseFormatter(abc.ABC):
 
     def digest(self, children, **kwargs) -> str:
         try:
+
+            if not isinstance(children, (str, dict, list)) and hasattr(children, 'dump'):
+                children = children.dump()
             
             if not children:
                 ret = ''

--- a/src/pydocmaker/backend/ex_docx.py
+++ b/src/pydocmaker/backend/ex_docx.py
@@ -7,9 +7,6 @@ import base64
 from typing import List
 import warnings
 
-import docx
-from docx.shared import Inches, Pt, RGBColor
-from docx import Document
 
 import tempfile
 import os
@@ -17,8 +14,6 @@ import os
 from pathlib import Path
 import zipfile, os, sys
 from io import BytesIO
-
-import markdown
 
 try:
     from pydocmaker.backend.baseformatter import BaseFormatter
@@ -43,6 +38,13 @@ try:
     from pydocmaker.backend import libreoffice_api
 except Exception as err:
     from . import libreoffice_api
+    
+try:
+    import docx
+    from docx.shared import Inches, Pt, RGBColor
+    from docx import Document
+except ImportError:
+    Document = None
 
 import logging
 
@@ -651,7 +653,9 @@ def convert(doc:List[dict], template = None, template_params=None, use_w32=False
 
 class docx_renderer(BaseFormatter):
     def __init__(self, template_path:str=None, make_blue=False) -> None:
-        self.d = docx.Document(template_path)
+        if Document is None:
+             raise ImportError("python-docx is not installed. Please install it to use the docx backend.")
+        self.d = Document(template_path)
         self.make_blue = make_blue
 
     def add_paragraph(self, newtext, *args, **kwargs):

--- a/src/pydocmaker/backend/ex_ipynb.py
+++ b/src/pydocmaker/backend/ex_ipynb.py
@@ -11,7 +11,7 @@ import re
 import uuid
 import os
 import base64
-import markdown
+
 from typing import List
 
 

--- a/src/pydocmaker/backend/ex_rich.py
+++ b/src/pydocmaker/backend/ex_rich.py
@@ -12,11 +12,8 @@ import uuid
 import os
 import base64
 import warnings
-import markdown
 from typing import List
 
-from jinja2 import Template
-import rich.box
 
 try:
     from pydocmaker.backend.baseformatter import BaseFormatter, _handle_template
@@ -29,21 +26,25 @@ try:
 except Exception as err:
     from .pandoc_api import can_run_pandoc, pandoc_convert
 
+try:
+    from pydocmaker.util import _raise_missing
+except Exception as err:
+    from ..util import _raise_missing
+    
+try:
+    from rich import box
+    from rich.console import Console, Group
+    from rich.text import Text
+    from rich.panel import Panel
+    from rich.markdown import Markdown
+    from rich.table import Table
+    from rich.align import Align
 
-import rich
-import rich_pixels
+except ImportError:
+    Console = None
 
-from rich.console import Console, Group
-from rich.text import Text
-from rich.panel import Panel
-from rich.markdown import Markdown
-from rich.table import Table
-from rich.align import Align
 
-from rich_pixels import Pixels
-from PIL import Image
-from rich.theme import Theme
-from rich.style import Style
+
 
 # # Define colors that are dark enough to be seen on white
 # light_bg_theme = Theme({
@@ -71,6 +72,9 @@ CONSOLE_WIDTH_MAX = 200
 
 
 def convert(doc:List[dict], stream=None, title:str=None, embed_images=True, **kwargs):
+    if Console is None:
+        raise ImportError('rich library is not installed. Please install it to use the rich backend.')
+        
     if title is None:
         title = f'{datetime.datetime.now().strftime("%Y-%m-%d %H%M")} my-pydoc'
     unknown_params = kwargs
@@ -136,8 +140,10 @@ class rich_renderer(BaseFormatter):
         else:
             s = 'rich text backend can not parse latex and no pandoc is available. Falling back to show as verbatim'
             warnings.warn(s)
-            return self.digest_text(children='Warning! ' + s, color='purple') + self.digest_verbatim(**kwargs)    
-
+            a = self.digest_text(children=f'Warning! {s}', color='purple') 
+            b = self.digest_verbatim(**kwargs)    
+            return Group(a, b)
+        
     
     def digest_markdown(self, **kwargs):
         label = kwargs.get('label', None)
@@ -153,7 +159,7 @@ class rich_renderer(BaseFormatter):
 
     def digest_iterator(self, **kwargs):
         content = kwargs.get('children', kwargs.get('content'))
-        return Group(([self.digest(c) for c in content]))
+        return Group(*[self.digest(c) for c in content])
 
     def digest_verbatim(self, **kwargs):
         label = kwargs.get('label', None)
@@ -165,6 +171,8 @@ class rich_renderer(BaseFormatter):
     
         
     def digest_image(self, **kwargs):
+        
+
         imageblob = kwargs.get('imageblob', None)
         children = kwargs.get('children', '')
         width = kwargs.get('width', None)
@@ -188,6 +196,9 @@ class rich_renderer(BaseFormatter):
             label = f'Figure {self.cnt_img}'
 
         if imageblob and self.embed_images:
+            from PIL import Image
+            from rich_pixels import Pixels
+
             if isinstance(imageblob, str):
                 if ';base64, ' in imageblob:
                     imageblob = imageblob.replace(';base64, ', ';base64,')
@@ -248,7 +259,7 @@ class rich_renderer(BaseFormatter):
         
         table = Table(title=caption, 
                       show_header = True if head else False, 
-                      box=rich.box.HEAVY_HEAD if borders else None)
+                      box=box.HEAVY_HEAD if borders else None)
 
         for h in head:
             table.add_column(h)

--- a/src/pydocmaker/backend/ex_tex.py
+++ b/src/pydocmaker/backend/ex_tex.py
@@ -19,7 +19,7 @@ from io import BytesIO
 import warnings
 
 import zipfile
-import latex
+
 from jinja2 import Template
 
 from typing import List
@@ -46,7 +46,12 @@ try:
     from pydocmaker.backend.pandoc_api import can_run_pandoc, pandoc_convert
 except Exception as err:
     from .pandoc_api import can_run_pandoc, pandoc_convert
-    
+
+try:
+    import latex
+except ImportError:
+    latex = None
+
 
 md = markdown.Markdown()
 latex_mdx = mdx_latex.LaTeXExtension()
@@ -107,6 +112,8 @@ RD[{{ i }}] & {{ value }} \\
 
 
 def escape(s):
+    if latex is None:
+        raise ImportError("The 'latex' package is required for escaping LaTeX special characters. Please install it using 'pip install latex'.")
     if isinstance(s, dict):
         return {k:latex.escape(v) for k, v in s.items()}
     elif isinstance(s, str):

--- a/src/pydocmaker/backend/ex_typst.py
+++ b/src/pydocmaker/backend/ex_typst.py
@@ -1,0 +1,468 @@
+import base64, time, io, copy, json, traceback, hashlib, markdown, re
+import warnings
+from typing import List, Union
+import json
+
+try:
+    from pydocmaker.backend.baseformatter import BaseFormatter, _handle_template
+except Exception as err:
+    from .baseformatter import BaseFormatter, _handle_template
+    
+try:
+    from pydocmaker import util
+except Exception as err:
+    from .. import util
+
+
+try:
+    from pydocmaker.backend.pandoc_api import can_run_pandoc, pandoc_convert, pandoc_convert_file
+except Exception as err:
+    from .pandoc_api import can_run_pandoc, pandoc_convert, pandoc_convert_file
+
+import logging
+
+# Configure once
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s | %(levelname)-8s | %(filename)-15s:%(lineno)3d] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+log = logging.getLogger(__name__)
+
+
+
+__default_template = """
+#set page(paper: "a4")
+#set heading(numbering: "1.")
+
+{% for library in libraries %}
+{{ library }}
+{% endfor %}
+
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
+#show table.cell.where(y: 0): set text(weight: "bold")
+
+// code blocks
+#let code-border = luma(0)
+// #show raw: set text(font: (fonts.mono), fallback: true)
+#show raw.where(block: false): set text(weight: "semibold")
+#show raw.where(block: true): set text(size: 0.8em)
+#show raw.where(block: true): it => {
+    block(
+        width:100%,
+        inset: 10pt,
+        radius: 4pt,
+        stroke: 0.1pt + code-border,
+        it,
+    )
+}
+
+#set figure(numbering: "1")
+#set figure.caption(separator: " - ") // With a nice separator
+#set math.equation(numbering: "(1)", supplement: "Eq.")
+
+//-------------------------------------
+// Metadata of the document
+//
+#let doc= (
+{% if title %}
+  title    : [*{{ title }}*],
+{% endif %}
+  
+
+{% if authors %}
+  authors: (
+{% for author in authors %}
+    (
+      name        : "{{ author }}",
+    ),
+{% endfor %}
+  ),
+{% elif author %}
+    (
+      name        : "{{ author }}",
+    ),
+{% endif %}
+
+  keywords : ("Typst", "Template", "Report", "pydocmaker"),
+  version  : "v0.1.0",
+)
+
+//-------------------------------------
+// Settings
+//
+
+{% if title %}
+= {{ title }}
+{% endif %}
+  
+
+
+#let date= datetime.today()
+
+{% if applicables or references or acronyms %}
+== References
+{% endif %}
+
+{% if acronyms %}
+
+=== List of Acronyms
+
+#let acronyms = (
+{% for key, value in acronyms.items() %}
+   "{{ key }}": "{{ value }}"
+{% endfor %}
+)
+
+#table(
+  columns: (2cm, 1fr),
+  stroke: none,
+  ..acronyms.pairs().map(((id, desc)) => (
+    [*#id*] + label(id),
+    desc
+  )).flatten()
+)
+
+{% endif %}
+
+
+{% if applicables %}
+
+=== Applicable Documents
+
+#let applicables = (
+{% for key, value in applicables.items() %}
+   "{{ key }}": "{{ value }}"
+{% endfor %}
+)
+
+#table(
+  columns: (2cm, 1fr),
+  stroke: none,
+  ..applicables.pairs().map(((id, desc)) => (
+    [*#id*] + label(id),
+    desc
+  )).flatten()
+)
+
+{% endif %}
+
+{% if references %}
+=== Reference Documents
+
+
+#let references = (
+{% for key, value in references.items() %}
+   "{{ key }}": "{{ value }}"
+{% endfor %}
+)
+
+#table(
+  columns: (2cm, 1fr),
+  stroke: none,
+  ..references.pairs().map(((id, desc)) => (
+    [*#id*] + label(id),
+    desc
+  )).flatten()
+)
+{% endif %}
+
+{{ body }}
+
+"""
+
+
+_table_template = """
+#figure(
+table(
+    columns: {n_cols:},
+    stroke: {stroke:},
+    align:(left+horizon),
+    {header:}
+    {rows:}
+),
+{suffix:}
+) <{name:}>
+
+"""
+
+_figure_template = """
+#figure(
+  image(base64.decode({name:}), {width:} format: "{ext:}"),
+  {suffix:}
+) <{name:}>
+"""
+
+DATA_URI_IMAGE_RE = re.compile(
+    r'^\s*data:image/(?P<mime>[A-Za-z0-9.+-]+)\s*;\s*base64\s*,\s*(?P<data>[A-Za-z0-9+/=\s]+)\s*$',
+    re.IGNORECASE,
+)
+
+def test_typst_installed():
+    try:
+        import typst
+        return True
+    except ImportError:
+        return False
+
+def to_typst_string(text):
+    # Escape backslashes first, then double quotes, then newlines
+    safe_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    return f'"{safe_text}"'
+
+def compile_with_typst(typst_code: Union[str, List[dict]], output: str = None, verb=1, on_warning='warn', format=None, **kwargs):
+    import typst
+
+    if not isinstance(typst_code, str):
+        typst_code = convert(typst_code)
+
+    typst_code = typst_code.encode('utf-8')
+    
+    format = format or ''
+
+    ext = None
+    if output and '.' in output:
+        ext = output.rsplit('.', 1)[-1].lower()
+    elif format:
+        ext = format.lower()
+    else:
+        ext = 'pdf'
+    
+    if on_warning is None:
+        on_warning = 'ignore'
+
+    kw = {
+        'input': typst_code,
+        'output': output,
+        'format': ext,
+        **kwargs
+    }
+    if verb:
+        logging.info(f'Compiling typst document to {output} format {ext} with typst compiler...')
+        res, warns = typst.compile_with_warnings(**kw)
+
+        if warns:
+            s = f'Typst compilation finished with warnings.'
+            for i, warn in enumerate(warns, 1):
+                s += f'\n\nWARNING {i}: {warn.message}\nDiagnostic: {warn.diagnostic}'
+                if warn.hints:
+                    s += '\nHints:\n' + '\n'.join(warn.hints)
+                if warn.trace:
+                    s += '\nTrace:\n' + '\n'.join(warn.trace)
+
+            if on_warning == 'warn':
+                warnings.warn(s)
+            elif on_warning == 'raise':
+                raise RuntimeError(s)
+            elif on_warning == 'log' or on_warning == 'logging':
+                log.warning(s)
+            elif on_warning == 'print':
+                print(s)
+            else:
+
+                logging.info(f'Compiling typst document... success')
+    
+    else:
+        res = typst.compile(**kw)
+
+    return res
+
+# def _typstraw():
+#     import typst
+#     compiler = typst.Compiler()
+#     compiler.compile(input="hello.typ", format="png", ppi=144.0)
+
+def convert(doc:List[dict], template = None, template_params=None, **kwargs):
+
+    if not template_params:
+        template_params = {}
+
+    unknown_params = kwargs
+    if unknown_params:
+        warnings.warn(f'Unknown parameters passed: {unknown_params=}')
+
+
+    formatter = DocumentTypstFormatter()
+    tmp = list(doc.values()) if isinstance(doc, dict) else doc
+    body = formatter.digest(tmp)
+
+    template_obj, attachments = _handle_template(template, __default_template)
+    
+
+
+    kw = copy.deepcopy(template_params)
+    if "librarries" in kw:
+        kw['libraries'].extend(formatter.libraries)
+    else:
+        kw['libraries'] = [x for x in formatter.libraries]
+
+    assert not ('body' in kw), f'the "body" keyword is an invalid keyword for templates as it is reserved for the document body.'
+    kw['body'] = body
+    
+    # typst can handle named references, so we can directly pass the dict to the template
+    # if 'applicables' in kw:
+    #     kw['applicables'] = {i:v for i, v in enumerate(kw['applicables'].values(), 1)} 
+    # if 'references' in kw:
+    #     kw['references'] = {i:v for i, v in enumerate(kw['references'].values(), 1)} 
+
+    doc_typst = template_obj.render(**kw)
+
+    return doc_typst
+
+
+
+class DocumentTypstFormatter(BaseFormatter):
+
+    def __init__(self) -> None:
+        self.cnt_img = 0
+        self.cnt_tables = 0
+        self.libraries = set()
+
+
+    def _handle_color(self, part, color=None, **kwargs):
+        if color:
+            s = '#text(fill: ' + color + ')[\n' + str(part) + '\n]\n'
+            return s
+        else:
+            return part
+        
+
+    def digest_latex(self, children: str, **kwargs):
+        s = None
+        if can_run_pandoc():
+            try:
+                s = pandoc_convert(children, 'latex', 'typst')
+                return self._handle_color(s, **kwargs)
+            except Exception as err:
+                s = 'Can not convert latex to typst! Embedding the latex code verbatim...\n\n'
+        else:
+            s = 'Pandoc is not available to convert latex to typst! Embedding the latex code verbatim...\n\n'
+        
+        s += self.digest_verbatim(children=children, lang='latex', **kwargs)
+        return self._handle_color(s, 'orange')
+
+    def digest_markdown(self, children='', **kwargs) -> list:
+        s = None
+        if can_run_pandoc():
+            try:
+                s = pandoc_convert(children, 'markdown', 'typst')
+            except Exception as err:
+                pass
+
+        if s is None:
+            self.libraries.add('#import "@preview/cmarker:0.1.8"')
+            self.libraries.add('#import "@preview/mitex:0.2.6": mitex')
+            safe_markdown = json.dumps(children) # escape all chars etc. and put quotes around it
+            s = f'#cmarker.render({safe_markdown}, math: mitex)'
+            
+        return self._handle_color(s, **kwargs)
+    
+    def digest_text(self, children='', **kwargs):
+        return self._handle_color(children, **kwargs)
+    
+    def digest_table(self, children=None, **kwargs) -> str:
+
+        borders = kwargs.pop('borders', None)
+        if borders is None:
+            borders = True
+        caption = kwargs.pop('caption', '')
+        if not caption:
+            caption = ''
+
+        name = kwargs.pop('name', None)
+
+        suffix = ' ' + f'caption: [{caption}],' if caption else ''
+        stroke = '0.5pt + rgb("666675")' if borders else "none"
+
+        head, mat = self._map_table2mat(children=children, **kwargs)
+
+        n_cols = len(mat[0]) if mat else (len(head) if head else 0)
+        n_rows = len(mat)
+        to_row = lambda row: ', '.join([f'[{s}]' for s in row])
+
+        header = f"table.header({to_row(head)})," if head else ''
+        rows = ',\n'.join([to_row(row) for row in mat])
+
+        self.cnt_tables += 1
+        name = f'table_{self.cnt_tables}' if not name else util.filename2identifier(name)
+        body = _table_template.format(n_cols=n_cols, n_rows=n_rows, stroke=stroke, header=header, rows=rows, suffix=suffix, name=name)
+        
+        return self._handle_color(body, **kwargs)
+
+   
+            
+
+    def digest_image(self, **kwargs) -> list:
+        
+        filename = kwargs.get('filename')
+        caption = kwargs.get('caption')
+        imageblob = kwargs.get('imageblob')
+        name = kwargs.get('name', filename)
+        width = kwargs.get('width', None)
+        
+        if name:
+            name = util.filename2identifier(name)
+        else:
+            name = f'image_{self.cnt_img+1}'
+        
+        description = caption or filename
+        if width is None:
+            width = ''
+        elif isinstance(width, (int, float)):
+            width = f'width: {int(width*100)}%,'
+        elif isinstance(width, str):
+            width = width
+        else:
+            width = str(width)
+
+
+        suffix = ' ' + f'caption: [{description}],' if description else ''
+        self.libraries.add('#import "@preview/based:0.2.0": base64')
+
+        imageblob_str = imageblob.decode('utf-8') if isinstance(imageblob, bytes) else str(imageblob)
+        mime_match = DATA_URI_IMAGE_RE.fullmatch(imageblob_str)
+        if mime_match:
+            ext = mime_match.group('mime').lower()
+            b64data = mime_match.group('data').replace('\n', '').replace('\r', '')            
+        elif filename and '.' in filename:
+            _, ext = filename.rsplit('.', 1)
+            ext = ext.lower()
+            b64data = imageblob_str.strip()
+        else:
+            ext = 'png'
+            b64data = imageblob_str.strip()
+
+        lines = ['']
+        lines.append(f'#let {name} = "{b64data}"')
+        lines.append('')
+        lines.append(_figure_template.format(name=name, ext=ext, width=width, suffix=suffix))
+        lines.append('')
+
+        self.cnt_img += 1
+
+        s =  '\n'.join(lines)
+        return self._handle_color(s, **kwargs)
+    
+
+    def digest_verbatim(self, children='', **kwargs) -> list:
+        lang = kwargs.pop('lang', kwargs.get('language', None))
+
+        if lang is None:
+            lang = ''
+        else:
+            lang = f'"{str(lang).strip()}"'
+
+
+        if isinstance(children, str):
+            txt = children.strip('\n') # to_typst_string(children) #.strip('\n')
+        else:
+            txt = self.digest(children)
+        
+        s = f"""```{lang}\n{txt}\n```"""
+        # s = f'\n#raw(`{}`, block: true, lang: {lang})\n\n'
+        
+        return self._handle_color(s, **kwargs)
+    
+        

--- a/src/pydocmaker/backend/pandoc_api.py
+++ b/src/pydocmaker/backend/pandoc_api.py
@@ -346,7 +346,6 @@ class PandocFormatter:
         if color:
             c = f'color:{color};'
             txt = f'<div style="{c}">{children}</div>'
-            print(txt)
             return self.conv(txt, 'html')
         else:
             return children

--- a/src/pydocmaker/backend/pandoc_api.py
+++ b/src/pydocmaker/backend/pandoc_api.py
@@ -88,6 +88,13 @@ def pandoc_set_allowed(is_allowed):
     allow_pandoc = True if is_allowed else False
     return allow_pandoc
 
+def pandoc_get_allowed():
+    """Get whether or not pandoc is allowed to be used as a valid conversion option"""
+    return allow_pandoc
+
+config_pandoc_allowed_set = pandoc_set_allowed
+config_pandoc_allowed_get = pandoc_get_allowed
+
 def pandoc_merge_files(inp_files, out_file):
     """
     Convert a file using pandoc.

--- a/src/pydocmaker/core.py
+++ b/src/pydocmaker/core.py
@@ -9,7 +9,7 @@ import time
 from typing import Any, Dict, List, BinaryIO, TextIO, Tuple, Union
 import warnings
 import zipfile
-import requests
+
 import base64
 import copy
 
@@ -30,7 +30,7 @@ from .backend.ex_redmine import convert as to_textile
 from .backend.ex_tex import make_pdf as to_pdf_tex
 from .backend.ex_tex import make_pdf_zip as to_pdf_zip
 from .backend.ex_rich import convert as print_rich
-
+from .backend.ex_typst import convert as to_typst, compile_with_typst as to_pdf_typst, test_typst_installed, compile_with_typst
 from .backend.ex_tex import auto_escape_latex
 
 from .backend.pdf_maker_tex import make_pdf_from_tex, config_latex_compiler_get, config_latex_compiler_set
@@ -47,6 +47,18 @@ chapter_level = 1 # this is the level of heading to use for chapters which is eq
 
 _pdf_engine = None
 _renderer_default = 'auto'
+
+import logging
+
+# Configure once
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s | %(levelname)-8s | %(filename)-15s:%(lineno)3d] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+log = logging.getLogger(__name__)
+
 
 def config_renderer_default_set(choice:str='auto'):
     """
@@ -77,13 +89,13 @@ def config_renderer_default_get():
 
 
 
-def config_pdf_engine_set(choice:str='tex'):
+def config_pdf_engine_set(choice:str='typst'):
     """
     Sets the PDF engine to be used for generating PDF documents.
 
     Parameters:
-    choice (str): The desired PDF engine. Must be one of 'tex', 'word', 'libreoffice', or 'pandoc'.
-                  Default is 'tex'.
+    choice (str): The desired PDF engine. Must be one of 'tex', 'word', 'libreoffice', 'typst', or 'pandoc'.
+                  Default is 'typst'.
 
     Returns:
     str: The selected PDF engine.
@@ -91,7 +103,7 @@ def config_pdf_engine_set(choice:str='tex'):
     Raises:
     ValueError: If the provided choice is not one of the allowed options.
     """
-    options = "tex word libreoffice pandoc".split()
+    options = "tex word libreoffice typst pandoc".split()
     choice = str(choice).lower()
     if not choice in options:
         raise ValueError(f'PDF engine must be one of {options=} but was {choice=}')
@@ -121,7 +133,9 @@ def config_pdf_engine_test(raise_on_error=True, force_reload=False):
     """
     res = False
     global _pdf_engine
-    if _pdf_engine == 'tex':
+    if _pdf_engine == 'typst':
+        res = test_typst_installed()
+    elif _pdf_engine == 'tex':
         res = config_latex_compiler_get()
     elif _pdf_engine == 'word':
         res = ex_docx.can_use_w32_word(force_reload=force_reload)
@@ -150,6 +164,8 @@ def config_pdf_engine_scan(force_reload=False, firstonly=False):
         bool: True if a valid compiler is found, False otherwise.
     """
     res = []
+    if test_typst_installed(): res.append('typst')
+    if firstonly and res: return res[0]
     if config_latex_compiler_get(): res.append('tex')
     if firstonly and res: return res[0]
     if ex_docx.can_use_w32_word(force_reload=force_reload): res.append('word')
@@ -353,7 +369,7 @@ class constr():
 
     @staticmethod
     def image_from_link(url, caption='', children='', width=None, color='', end=None):
-
+        import requests
         assert url, 'need to give an URL!'
 
         response = requests.get(url)
@@ -505,8 +521,8 @@ class Doc(UserList):
     """a collection of document parts to make a document (can be used like a list)"""
 
     DEFAULT_ADD_STRING_TYPE = 'markdown'
-    EXPORT_ENGINES = ['md', 'html', 'json', 'docx', 'textile', 'ipynb', 'tex', 'redmine', 'pdf']
-    EXPORT_ENGINES_EXTENSIONS = {'md': '.md', 'html':'.html', 'json':'.json', 'docx': '.docx', 'textile': '.textile.zip', 'ipynb': '.ipynb', 'tex': '.tex.zip', 'pdf': '.pdf'}
+    EXPORT_ENGINES = ['md', 'html', 'typst', 'json', 'docx', 'textile', 'ipynb', 'tex', 'redmine', 'pdf']
+    EXPORT_ENGINES_EXTENSIONS = {'md': '.md', 'html':'.html', 'typst': '.typ', 'json':'.json', 'docx': '.docx', 'textile': '.textile.zip', 'ipynb': '.ipynb', 'tex': '.tex.zip', 'pdf': '.pdf'}
 
     @staticmethod
     def load_json(path):
@@ -674,13 +690,23 @@ class Doc(UserList):
         """
         meta = self.get_meta({}).get("data", {})
         template_id = meta.get("template_id", None)
+
+        attachments = meta.get("files_to_upload", {})
+        attachments.update(meta.get("attachments", {}))
+        attachments = {k:base64.b64decode(v) if isinstance(v, str) else v for k, v in attachments.items()}
+    
         if template_id is None:
-            return None    
+            template_str = meta.get("template", None)
+            if template_str:
+                return DocTemplate(template_str, attachments=attachments)
+            else:
+                return None    
+        
+
         try:
             template = DocTemplate.from_tid(template_id, tformat, template_dir)
             template.params = {k:v for k, v in meta.items() if k in template.params}
-            attachments = meta.get("files_to_upload", {})
-            attachments = {k:base64.b64decode(v) if isinstance(v, str) else v for k, v in attachments.items()}
+
             template.attachments.update(attachments)
             return template
         except KeyError as err:
@@ -1210,6 +1236,34 @@ class Doc(UserList):
 
         return self._ret(to_html(self.dump(), template=template, template_params=template_params), path_or_stream)
 
+    def to_typst(self, path_or_stream=None, template=None, template_params=None) -> str:
+        """
+        Converts the current object to a Typst file.
+
+        Args:
+            path_or_stream (str or io.IOBase, optional): The path to save the file to, or a file-like object to write the data to. If not provided, the data will be returned as string.
+            template (str, optional): A string containing the LaTeX code for the document template. Either a Jinja2 Latex template, or a string
+                If not provided, a default template will be used.
+            template_params (dict, optional): A dictionary containing the parameters for the document template which will be parsed to the "render" method of Jinja2
+
+        Returns:
+            str: The data as string, or True if the data was saved successfully to a file or stream.
+        """
+        params = {}
+        meta = self.get_meta(default={}).get('data', {})
+        mytemplate = self.get_template_from_meta(tformat='typst')
+        if template is None and not mytemplate is None:
+            template = mytemplate.template
+        if not mytemplate is None:
+            params_from_meta = mytemplate.params
+        else:
+            params_from_meta = {k:v for k, v in meta.items() if not k in ["template_id", "files_to_upload", "additional_files"]}
+        params.update(params_from_meta)
+
+        if template_params:
+            params.update(template_params)
+
+        return self._ret(to_typst(self.dump(), template=template, template_params=template_params), path_or_stream)
         
 
     def to_pdf(self, path_or_stream=None, docname='', files_to_upload=None, base_dir=None, engine=None, latex_compiler=None, n_times_make=None, verb=0, ignore_error=True, template=None, template_params=None, do_escape_template_params='auto', **kwargs) -> Union[str, bytes, bool]:
@@ -1225,10 +1279,10 @@ class Doc(UserList):
             files_to_upload (optional): A list of files to be uploaded with the document.
             base_dir (str, optional): The directory to use as the base directory for the temporary directory.
                 Defaults to the system's default temporary directory.
-            engine (str, optional): the pdf engine to use (either "tex", "word", or "libreoffice"). If None, the currently configured default engine will be used.
+            engine (str, optional): the pdf engine to use (either "typst", "tex", "word", or "libreoffice"). If None, the currently configured engine will be queried via config_pdf_engine_get().
             latex_compiler (str, optional): Only used if engine resolves to "tex". The LaTeX compiler to use. Either 'pdflatex', 'lualatex', 'xelatex', or 'pandoc'.
                 If not specified, the function will try to use 'pandoc', 'pdflatex', 'lualatex', or 'xelatex' in that order.
-            n_times_make (int, optional): The number of times to run the LaTeX compiler. Defaults to 1 for pandoc and 3 for all others.
+            n_times_make (int, optional): Only used if engine resolves to "tex". The number of times to run the LaTeX compiler. Defaults to 1 for pandoc and 3 for all others.
             verb (int, optional): The verbosity level (0, 1, 2). If greater than 0, the function will print more and more debug information. Defaults to 0.
             ignore_error (bool, optional): Whether to ignore errors during the LaTeX compilation. Defaults to True.
             template (str, optional): A string containing the LaTeX code for the document template. Either a Jinja2 Latex template, or a string
@@ -1258,20 +1312,24 @@ class Doc(UserList):
 
         if not engine:
             raise ImportError("No engine to convert to PDF is available. Make sure you either have pdflatex, Microsoft Word, or Libreoffice installed")
-        
-        tformat = 'tex' if engine == 'tex' else 'html'
+
+        if verb:
+            log.info(f'using engine "{engine}" to convert to pdf')
+
+        tformat = 'tex' if engine == 'tex' else ('typst' if engine == 'typst' else 'html')
+
         mytemplate = self.get_template_from_meta(tformat=tformat)
         if template is None and not mytemplate is None:
             template = mytemplate.template
         if not mytemplate is None:
             if verb:
-                print(f'found template "{mytemplate.template_id}"')
+                log.info(f'found template "{mytemplate.template_id}"')
             params_from_meta = mytemplate.params
             if verb:
-                print(f'found params: "{params_from_meta.keys()=}"')
+                log.info(f'found params: "{params_from_meta.keys()=}"')
             files_to_upload = {**mytemplate.attachments, **files_to_upload}
             if verb:
-                print(f'found attachments: "{files_to_upload.keys()=}"')
+                log.info(f'found attachments: "{files_to_upload.keys()=}"')
         else:
             params_from_meta = {k:v for k, v in meta.items() if not k in ["template_id", "files_to_upload", "additional_files"]}
         params.update(params_from_meta)
@@ -1279,8 +1337,20 @@ class Doc(UserList):
         if template_params:
             params.update(template_params)
 
+        if engine == 'typst':
+            def _to_pdf_typst(*ar, **kw):
+                s = self.to_typst(*ar, template=template, template_params=params, **kw)
+                if ignore_error and verb:
+                    on_warning = 'warn' 
+                elif ignore_error and not verb:
+                    on_warning = 'ignore'
+                elif verb:
+                    on_warning = 'log'
 
-        if engine == 'tex':
+                return to_pdf_typst(s, verb=verb, on_warning=on_warning)
+
+            fun = _to_pdf_typst
+        elif engine == 'tex':
             
             if do_escape_template_params == 'auto':
                 params = auto_escape_latex(params)
@@ -1352,6 +1422,8 @@ class Doc(UserList):
                         bts = fp.read()
                 return bts
             fun = to_pdf_pandoc
+
+
         else:
             raise ValueError("unknown engine, Engine must be one of 'tex', 'word', 'libreoffice'")
         
@@ -1359,7 +1431,7 @@ class Doc(UserList):
         r = self._ret(fun(self.dump(), **kwargs), path_or_stream)
 
         if isinstance(path_or_stream, (str, os.PathLike)) and verb:
-            print(f'Saved to path_or_stream="{path_or_stream}" with function "{fun.__name__}"')
+            log.info(f'Saved to path_or_stream="{path_or_stream}" with function "{fun.__name__}"')
 
         return r
     
@@ -1538,6 +1610,14 @@ class Doc(UserList):
     def to_pdf_print(self, path_or_stream=None):
         """Exports the document to a PDF file by using the systems "print to pdf" function to export from html to pdf.
 
+        WARNING: This function only works on posix like operating systems and requires a PDF printer to be installed 
+        and set as default printer. It will not work on windows or macos since they do not have a command line 
+        interface for printing to PDF. Use with caution and make sure to test it on your system before using it in production!
+
+        WARNING II: The resulting PDF file will not be of the same quality as a PDF file generated by a proper PDF engine like 
+        pdflatex, typst, or word. It is recommended to use this function only as a last resort if no other PDF engine is 
+        available and you need a quick and dirty PDF file.
+
         Args:
             output_pdf_path (str, optional): The path to save the PDF file to. If not provided, a temporary file will be used.
             
@@ -1668,6 +1748,8 @@ class Doc(UserList):
             return self.to_json(path_or_stream=path_or_stream, **kwargs)
         elif engine in ['html']:
             return self.to_html(path_or_stream=path_or_stream, **kwargs)
+        elif engine in ['typst', 'typ', 'TYPST', 'TYP']:
+            return self.to_typst(path_or_stream=path_or_stream, **kwargs)
         elif engine in ['pdf']:
             return self.to_pdf(path_or_stream=path_or_stream, **kwargs)
         elif engine in ['tex', 'latex']:
@@ -1717,6 +1799,8 @@ class Doc(UserList):
             "force_overwrite": force_overwrite,
             "page_title": page_title
         }
+
+        import requests
 
         requests_kwargs = {} if not requests_kwargs else None
         r = requests.post(url, json=upload, **requests_kwargs)
@@ -1780,6 +1864,8 @@ class Doc(UserList):
                 self.print_rich(embed_images=embed_images, **kwargs)
             elif engine in 'markdown md'.split():
                 display(Markdown(self.to_markdown(embed_images=embed_images, **kwargs)))
+            elif engine in 'typst'.split():
+                display(Code(self.to_typst(**kwargs), language='typst'))
             elif engine in 'tex latex'.split():
                 display(Code(self.to_tex(text_only=True, **kwargs), language='tex'))
             elif engine == 'pdf':
@@ -1787,7 +1873,7 @@ class Doc(UserList):
                 pdf_bytes = self.to_pdf(verb=verb, **kwargs)
                 show_pdf(pdf_bytes)
             else:
-                raise KeyError(f'engine must be in: "html", "markdown", "md", "tex", "latex", or "pdf", but was {engine=}')
+                raise KeyError(f'engine must be in: "html", "markdown", "md", "typst", "tex", "latex", or "pdf", but was {engine=}')
 
         else:
             if engine == 'auto':
@@ -1801,10 +1887,12 @@ class Doc(UserList):
             elif engine in 'markdown md'.split():
                 kwargs.pop('embed_images')
                 print(self.to_markdown(embed_images=False, **kwargs))
+            elif engine in 'typst'.split():
+                print(self.to_typst(**kwargs))
             elif engine in 'tex latex'.split():
                 print(self.to_tex(text_only=True, **kwargs))
             else:
-                raise KeyError(f'engine must be in: "html", "markdown", "md", "tex", or "latex", but was {engine=}')
+                raise KeyError(f'engine must be in: "html", "markdown", "md", "typst", "tex", or "latex", but was {engine=}')
             
     def __repr__(self, *args, **kwargs):
         chaps = self.get_chapters()
@@ -1930,6 +2018,15 @@ def load(doc:List[dict]):
 def print_to_pdf(file_path, output_pdf_path):
     """Prints a file to a PDF file using the appropriate platform-specific command using subprocess
 
+    WARNING: This function only works on posix like operating systems and requires a PDF printer to be installed 
+    and set as default printer. It will not work on windows or macos since they do not have a command line 
+    interface for printing to PDF. Use with caution and make sure to test it on your system before using it in production!
+
+    WARNING II: The resulting PDF file will not be of the same quality as a PDF file generated by a proper PDF engine like 
+    pdflatex, typst, or word. It is recommended to use this function only as a last resort if no other PDF engine is 
+    available and you need a quick and dirty PDF file.
+
+    
     Args:
         file_path (str): The path to the file to print.
         output_pdf_path (str): The path to the output PDF file.

--- a/src/pydocmaker/datamodel.json
+++ b/src/pydocmaker/datamodel.json
@@ -1,0 +1,53 @@
+[{
+    "typ": "meta",
+    "children": "object",
+    "data": "object"
+},{
+    "typ": "markdown",
+    "children": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "text",
+    "children": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "line",
+    "children": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "latex",
+    "children": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "verbatim",
+    "children": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "iter",
+    "children": "array",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "table",
+    "children": "array",
+    "n_cols": "number",
+    "n_rows": "number",
+    "borders": "boolean",
+    "header": "array",
+    "caption": "string",
+    "color": "string",
+    "end": "string"
+},{
+    "typ": "image",
+    "children": "string",
+    "imageblob": "string",
+    "caption": "string",
+    "width": "number",
+    "color": "string",
+    "end": "string"
+}]

--- a/src/pydocmaker/util.py
+++ b/src/pydocmaker/util.py
@@ -8,6 +8,7 @@ import time
 import random
 import string
 from enum import Enum
+import re
 
 class bcolors(Enum):
     HEADER = '\033[95m'
@@ -214,3 +215,28 @@ def upload_report_to_redmine(doc, redmine, project_id, report_name=None, page_ti
         page.save()
 
         return page.url if page else ''
+
+
+
+
+def filename2identifier(filename):
+    """Converts a filename to a valid identifier by:
+    1. Stripping the file extension
+    2. Replacing any non-alphanumeric character with an underscore
+    3. Ensuring it doesn't start with a digit
+    """
+    name = filename.rsplit('.', 1)[0]
+    identifier = re.sub(r'[^a-zA-Z0-9_]', '_', name)
+    if identifier[0].isdigit():
+        identifier = '_' + identifier
+        
+    return identifier
+
+class _raise_missing:
+    def __init__(self, *args, **kwargs):
+        raise ImportError('latex package not found. This needs the full pydocmaker installation. Please install pydocmaker with "pip install pydocmaker[full]" to use this function.')
+    
+    @classmethod
+    def __getattr__(self, name):
+        raise ImportError('latex package not found. This needs the full pydocmaker installation. Please install pydocmaker with "pip install pydocmaker[full]" to use this function.')
+    

--- a/tests/test_ex_typst.py
+++ b/tests/test_ex_typst.py
@@ -1,79 +1,36 @@
 import unittest
 import os, inspect, sys, base64
-from unittest.mock import patch, MagicMock
 
 current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, os.path.join(parent_dir, 'src'))
 
 from pydocmaker.backend import ex_typst
-from pydocmaker.backend.pandoc_api import pandoc_set_allowed
+
 
 class TestTypstRenderer(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.formatter = ex_typst.DocumentTypstFormatter()
+        self.formatter = ex_typst.DocumentMarkdownFormatter()
 
     def test_digest_image_data_uri_any_image_format(self):
         payload = base64.b64encode(b'abcd').decode('ascii')
-        blob = f'data:image/jpeg;base64,{payload}'
+        blob = f'data:image/jpeg; base64,{payload}'
         result = self.formatter.digest({'typ': 'image', 'filename': 'test.jpg', 'imageblob': blob})
         self.assertIsInstance(result, str)
-        self.assertIn('format: "jpeg"', result)
-        self.assertIn(payload, result)
+        self.assertIn('data:image/jpeg;base64,', result)
+
+    def test_digest_image_ext_mismatch_raises(self):
+        payload = base64.b64encode(b'abcd').decode('ascii')
+        blob = f'data:image/png;base64,{payload}'
+        with self.assertRaises(ValueError):
+            self.formatter.digest({'typ': 'image', 'filename': 'test.jpg', 'imageblob': blob})
 
     def test_digest_image_plain_base64_uses_filename_ext(self):
         payload = base64.b64encode(b'abcd').decode('ascii')
         result = self.formatter.digest({'typ': 'image', 'filename': 'test.png', 'imageblob': payload})
-        self.assertIn('format: "png"', result)
+        self.assertIn('data:image/png;base64,', result)
 
-    def test_digest_text(self):
-        result = self.formatter.digest({'typ': 'text', 'children': 'hello world'})
-        self.assertIn('hello world', result)
-
-    def test_digest_markdown(self):
-        pandoc_set_allowed(True)
-        result = self.formatter.digest({'typ': 'markdown', 'children': '# Title'})
-        self.assertIsInstance(result, str)
-        # Check if it uses the cmarker fallback or pandoc output
-        self.assertTrue('cmarker' in result or 'Title' in result)
-        
-        pandoc_set_allowed(False)
-        result = self.formatter.digest({'typ': 'markdown', 'children': '# Title'})
-        self.assertIsInstance(result, str)
-        # Check if it uses the cmarker fallback or pandoc output
-        self.assertTrue('cmarker' in result or 'Title' in result)
-        
-    def test_digest_verbatim(self):
-        result = self.formatter.digest({'typ': 'verbatim', 'children': 'code snippet'})
-        self.assertIn('```', result)
-        self.assertIn('code snippet', result)
-
-    def test_digest_latex(self):
-        result = self.formatter.digest({'typ': 'latex', 'children': '$x^2$'})
-        self.assertIsInstance(result, str)
-
-    def test_digest_table(self):
-        data = {
-            'typ': 'table',
-            'children': [['a', 'b']],
-            'header': ['col1', 'col2'],
-            'caption': 'Test Table'
-        }
-        result = self.formatter.digest(data)
-        self.assertIn('table(', result)
-        self.assertIn('Test Table', result)
-
-    def test_convert(self):
-        doc = [{'typ': 'text', 'children': 'test doc'}]
-        result = ex_typst.convert(doc)
-        self.assertIn('test doc', result)
-
-    @patch('typst.compile')
-    def test_compile_with_typst(self, mock_compile):
-        mock_compile.return_value = b'pdf data'
-        with patch('pydocmaker.backend.ex_typst.test_typst_installed', return_value=True):
-            result = ex_typst.compile_with_typst('typst code', verb=0)
-            self.assertEqual(result, b'pdf data')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ex_typst.py
+++ b/tests/test_ex_typst.py
@@ -1,0 +1,79 @@
+import unittest
+import os, inspect, sys, base64
+from unittest.mock import patch, MagicMock
+
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parent_dir = os.path.dirname(current_dir)
+
+from pydocmaker.backend import ex_typst
+from pydocmaker.backend.pandoc_api import pandoc_set_allowed
+
+class TestTypstRenderer(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.formatter = ex_typst.DocumentTypstFormatter()
+
+    def test_digest_image_data_uri_any_image_format(self):
+        payload = base64.b64encode(b'abcd').decode('ascii')
+        blob = f'data:image/jpeg;base64,{payload}'
+        result = self.formatter.digest({'typ': 'image', 'filename': 'test.jpg', 'imageblob': blob})
+        self.assertIsInstance(result, str)
+        self.assertIn('format: "jpeg"', result)
+        self.assertIn(payload, result)
+
+    def test_digest_image_plain_base64_uses_filename_ext(self):
+        payload = base64.b64encode(b'abcd').decode('ascii')
+        result = self.formatter.digest({'typ': 'image', 'filename': 'test.png', 'imageblob': payload})
+        self.assertIn('format: "png"', result)
+
+    def test_digest_text(self):
+        result = self.formatter.digest({'typ': 'text', 'children': 'hello world'})
+        self.assertIn('hello world', result)
+
+    def test_digest_markdown(self):
+        pandoc_set_allowed(True)
+        result = self.formatter.digest({'typ': 'markdown', 'children': '# Title'})
+        self.assertIsInstance(result, str)
+        # Check if it uses the cmarker fallback or pandoc output
+        self.assertTrue('cmarker' in result or 'Title' in result)
+        
+        pandoc_set_allowed(False)
+        result = self.formatter.digest({'typ': 'markdown', 'children': '# Title'})
+        self.assertIsInstance(result, str)
+        # Check if it uses the cmarker fallback or pandoc output
+        self.assertTrue('cmarker' in result or 'Title' in result)
+        
+    def test_digest_verbatim(self):
+        result = self.formatter.digest({'typ': 'verbatim', 'children': 'code snippet'})
+        self.assertIn('```', result)
+        self.assertIn('code snippet', result)
+
+    def test_digest_latex(self):
+        result = self.formatter.digest({'typ': 'latex', 'children': '$x^2$'})
+        self.assertIsInstance(result, str)
+
+    def test_digest_table(self):
+        data = {
+            'typ': 'table',
+            'children': [['a', 'b']],
+            'header': ['col1', 'col2'],
+            'caption': 'Test Table'
+        }
+        result = self.formatter.digest(data)
+        self.assertIn('table(', result)
+        self.assertIn('Test Table', result)
+
+    def test_convert(self):
+        doc = [{'typ': 'text', 'children': 'test doc'}]
+        result = ex_typst.convert(doc)
+        self.assertIn('test doc', result)
+
+    @patch('typst.compile')
+    def test_compile_with_typst(self, mock_compile):
+        mock_compile.return_value = b'pdf data'
+        with patch('pydocmaker.backend.ex_typst.test_typst_installed', return_value=True):
+            result = ex_typst.compile_with_typst('typst code', verb=0)
+            self.assertEqual(result, b'pdf data')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pdf_ex.py
+++ b/tests/test_pdf_ex.py
@@ -48,3 +48,20 @@ class TestMakePdfs(unittest.TestCase):
         
         self.assertTrue(bts.startswith(b'%PDF'), str(bts)[:20])
     
+
+
+    def test_pdf_typst(self):
+        templatepath = None
+        metadata = None
+        doc = pyd.Doc.get_example()
+        bts = doc.to_pdf(engine='typst', template=templatepath, template_params=metadata, verb=0)
+        self.assertTrue(bts)
+        self.assertIsInstance(bts, bytes)
+        self.assertTrue(bts.startswith(b'%PDF'), str(bts)[:20])
+
+        doc = pyd.Doc.get_example()
+        bts = doc.to_pdf(engine='typst', template=templatepath, template_params=metadata, verb=0)
+        self.assertTrue(bts)
+        self.assertIsInstance(bts, bytes)
+        
+        self.assertTrue(bts.startswith(b'%PDF'), str(bts)[:20])

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -42,7 +42,7 @@ class TestCodeSnippets(unittest.TestCase):
     def test_s3_export_html(self):
         self._test_s3_export('html', 'temp_outfile.html')
 
-    @unittest.skipUnless(os.name == 'nt' or os.environ.get('PYDOCMAKER_TESTFULL'), "Skipping since test requires optional dependencies")
+    #@unittest.skipUnless(os.name == 'nt' or os.environ.get('PYDOCMAKER_TESTFULL'), "Skipping since test requires optional dependencies")
     def test_s3_export_pdf(self):
         self._test_s3_export('pdf', 'temp_outfile.pdf')
 


### PR DESCRIPTION
v2.6.0: added support for typst, and made it the default PDF engine.
Also re-structured dependencies and made many imports optional so we can in principle use the library in a "light way" style in future. for legacy reasons I keep it as is.