### PR TITLE
fix: pass merged template_params to backend renderers in to_html and to_tex

### DIFF
--- a/src/pydocmaker/core.py
+++ b/src/pydocmaker/core.py
@@ -1255,7 +1255,12 @@ class Doc(UserList):
         if template_params:
             params.update(template_params)
 
-        return self._ret(to_html(self.dump(), template=template, template_params=template_params), path_or_stream)
+        # Pass the fully-merged `params` (meta defaults + caller overrides) to the
+        # backend renderer, not the raw `template_params` argument. Using the raw
+        # argument silently dropped parameters set via set_template_to_meta()
+        # or stored in document metadata, causing templates to render with
+        # missing fields (e.g. empty <title>, missing references table).
+        return self._ret(to_html(self.dump(), template=template, template_params=params), path_or_stream)
 
     def to_typst(self, path_or_stream=None, template=None, template_params=None) -> str:
         """
@@ -1524,8 +1529,12 @@ class Doc(UserList):
             params = auto_escape_latex(params)
             do_escape_template_params = False
 
-
-        tex, files = to_tex(self.dump(), with_attachments=True, template=template, files_to_upload=additional_files, do_escape_template_params=do_escape_template_params, template_params=template_params)
+        # Pass the fully-merged `params` (meta defaults + caller overrides) to the
+        # backend renderer, not the raw `template_params` argument. Using the raw
+        # argument silently dropped parameters set via set_template_to_meta()
+        # or stored in document metadata, so LaTeX templates rendered without
+        # their configured defaults.
+        tex, files = to_tex(self.dump(), with_attachments=True, template=template, files_to_upload=additional_files, do_escape_template_params=do_escape_template_params, template_params=params)
 
         with io.BytesIO() as in_memory_zip:
             with zipfile.ZipFile(in_memory_zip, 'w') as zipf:


### PR DESCRIPTION
## What was broken

```
File "/usr/local/lib/python3.12/site-packages/jinja2/utils.py", line 515, in __getitem__
    rv = self._mapping[key]
TypeError: unhashable type: 'dict'
```

The user (in a FastAPI app) hit this when calling `doc.to_html(template='')` with a document that has a `template_id` set via `set_template_to_meta()`. The downstream Starlette template render eventually failed because `doc_html` came back without the parameters the user had attached to the template.

## Root cause

In `src/pydocmaker/core.py`, `Doc.to_html()` and `Doc.to_tex()` carefully built a `params` dict by merging metadata defaults with the caller's `template_params`:

```python
params = {}
meta = self.get_meta(default={}).get('data', {})
mytemplate = self.get_template_from_meta(tformat='html')
...
if not mytemplate is None:
    params_from_meta = mytemplate.params
else:
    params_from_meta = {k:v for k, v in meta.items() if not k in [...]}
params.update(params_from_meta)

if template_params:
    params.update(template_params)
```

…and then *threw the merged `params` away* on the final call, passing the raw `template_params` argument (which is often `None`) instead:

```python
return self._ret(to_html(self.dump(), template=template, template_params=template_params), path_or_stream)
#                                                                 ^^^^^^^^^^^^^^^^^^^^^
#                                                                 was the function arg, not the merged dict
```

So any field the user had attached to the template via `set_template_to_meta(..., template_params={'title': ..., 'references': ...})` was silently dropped. The HTML template (e.g. `base.html.j2`) then rendered an empty `<title>`, a missing references table, and so on. `Doc.to_typst()` did the right thing already; only the HTML and LaTeX paths were affected.

## Fix

Use the merged `params` dict in the final call, matching what `to_typst` already does:

```python
return self._ret(to_html(self.dump(), template=template, template_params=params), path_or_stream)
```

```python
tex, files = to_tex(self.dump(), ..., template_params=params)
```

Caller-supplied `template_params` still take precedence because they're merged into `params` last.

## Testing

Verified locally with the installable package:

- `set_template_to_meta('base', template_params={'title': 'My Title'})` followed by `doc.to_html()` now produces `<title>My Title</title>` (was empty before).
- `set_template_to_meta('base', template_params={'references': {'r1': 'val1'}})` followed by `doc.to_html()` now renders the references table with the value (was missing before).
- Passing `template_params={'title': 'Override'}` to `to_html()` still overrides the metadata default (caller precedence preserved).
- `to_html(template='')` (the call from the bug report) still works.
- Basic `to_html()` with no template_id set still works.

Fixes #9